### PR TITLE
add an optional flag to use a monday-first calendar in the yearly view

### DIFF
--- a/app/api/wallpaper/route.tsx
+++ b/app/api/wallpaper/route.tsx
@@ -15,6 +15,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = request.nextUrl;
     const width = parseInt(searchParams.get('width') || '1170');
     const height = parseInt(searchParams.get('height') || '2532');
+    const isMondayFirst = searchParams.get('isMondayFirst') === '1';
     const viewMode = searchParams.get('viewMode') || 'year';
     const birthDate = searchParams.get('birthDate') || '';
 
@@ -24,7 +25,7 @@ export async function GET(request: NextRequest) {
       content = <LifeView width={width} height={height} birthDate={birthDate} />;
     } else {
       // Default to Year View
-      content = <YearView width={width} height={height} />;
+      content = <YearView width={width} height={height} isMondayFirst={isMondayFirst} />;
     }
 
     return new ImageResponse(

--- a/app/api/wallpaper/year-view.tsx
+++ b/app/api/wallpaper/year-view.tsx
@@ -7,9 +7,10 @@ import {
 interface YearViewProps {
     width: number;
     height: number;
+    isMondayFirst: boolean;
 }
 
-export function YearView({ width, height }: YearViewProps) {
+export function YearView({ width, height, isMondayFirst }: YearViewProps) {
     // Colors Config
     const BG_COLOR = '#1a1a1a'; // Dark background
     const TEXT_COLOR = '#888888'; // Grey for text
@@ -66,6 +67,10 @@ export function YearView({ width, height }: YearViewProps) {
     };
 
     const getFirstDayOfMonth = (year: number, monthIndex: number) => {
+        if (isMondayFirst) {
+            const day = new Date(year, monthIndex, 1).getDay();
+            return (day === 0 ? 6 : day - 1);
+        }
         return new Date(year, monthIndex, 1).getDay(); // 0 = Sun, etc.
     };
 


### PR DESCRIPTION
This PR adds support for configuring the first day of the week in the yearly view by introducing a new `isMondayFirst` parameter.

When enabled, the yearly calendar layout starts weeks on Monday instead of the default Sunday, allowing the API output to better match regional and user preferences.

**Details**
- Added a new optional query parameter: isMondayFirst
- Applies specifically to the yearly view
- When set to 1, weeks start on Monday
- Default behavior remains unchanged (Sunday-first) to preserve backward compatibility

**Usage Example**
/api/wallpaper?themeColor=FFFFFF&width=1320&height=2868&viewMode=year&**isMondayFirst=1**

**Notes**
- Existing routes are unaffected unless the parameter is explicitly provided
- This improves internationalization support, especially for regions where Monday is considered the first day of the week


**Example**

<img width="519" height="696" alt="kép" src="https://github.com/user-attachments/assets/45b50fe0-cbc3-4ddc-ab2c-d3eb6923221a" />
