### PR TITLE
feat: add goal view wallpaper flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+.next-dev.out.log
+.next-dev.err.log
 
 # env files (can opt-in for committing if needed)
 .env

--- a/app/api/[username]/route.tsx
+++ b/app/api/[username]/route.tsx
@@ -191,7 +191,7 @@ export async function GET(
       config.viewMode === 'student' &&
       (!config.studyStartDate || !config.universityName || !config.studyDurationYears)
     ) {
-      return new Response('Student details are required for Student View. Please configure in dashboard.', { status: 400 });
+      return new Response('Goal details are required for Goal View. Please configure in dashboard.', { status: 400 });
     }
     
     if (!config.device || !config.device.width || !config.device.height) {
@@ -217,7 +217,7 @@ export async function GET(
       });
 
       if (!normalized.ok) {
-        return new Response(`Invalid student view configuration: ${normalized.error}`, { status: 400 });
+        return new Response(`Invalid goal view configuration: ${normalized.error}`, { status: 400 });
       }
 
       studentInput = normalized.value;

--- a/app/api/[username]/route.tsx
+++ b/app/api/[username]/route.tsx
@@ -189,7 +189,7 @@ export async function GET(
 
     if (
       config.viewMode === 'student' &&
-      (!config.studyStartDate || !config.universityName || !config.studyDurationYears)
+      (!config.studyStartDate || !config.universityName || (!config.goalEndDate && !config.studyDurationYears))
     ) {
       return new Response('Goal details are required for Goal View. Please configure in dashboard.', { status: 400 });
     }
@@ -206,13 +206,14 @@ export async function GET(
     }
 
     let studentInput:
-      | { studyStartDate: string; universityName: string; studyDurationYears: number }
+      | { studyStartDate: string; universityName: string; goalEndDate: string; studyDurationYears: number }
       | null = null;
 
     if (config.viewMode === 'student') {
       const normalized = normalizeStudentViewInput({
         studyStartDate: config.studyStartDate || '',
         universityName: config.universityName || '',
+        goalEndDate: config.goalEndDate || '',
         studyDurationYears: config.studyDurationYears || '',
       });
 
@@ -223,6 +224,7 @@ export async function GET(
       studentInput = normalized.value;
       config.studyStartDate = studentInput.studyStartDate;
       config.universityName = studentInput.universityName;
+      config.goalEndDate = studentInput.goalEndDate;
       config.studyDurationYears = studentInput.studyDurationYears;
     }
 
@@ -277,6 +279,7 @@ export async function GET(
           birthDate: config.birthDate,
           studyStartDate: config.studyStartDate,
           universityName: config.universityName,
+          goalEndDate: config.goalEndDate,
           studyDurationYears: config.studyDurationYears,
           viewMode: config.viewMode,
           timezone: userTimezone,
@@ -328,7 +331,7 @@ export async function GET(
         ...viewProps,
         studyStartDate: studentInput?.studyStartDate || '',
         universityName: studentInput?.universityName || 'University',
-        studyDurationYears: studentInput?.studyDurationYears || 4,
+        goalEndDate: studentInput?.goalEndDate || '',
       });
     } else {
       view = YearView({

--- a/app/api/[username]/route.tsx
+++ b/app/api/[username]/route.tsx
@@ -13,8 +13,10 @@ import { getUserConfigByUsername, getPlugin, logWallpaperEvent } from '@/lib/fir
 import { Plugin, UserConfig } from '@/lib/types';
 import { isPlanExpired } from '@/lib/plan-utils';
 import { loadPluginFromCode } from '@/lib/plugin-system';
+import { isSafeWallpaperDimension, normalizeStudentViewInput } from '@/lib/student-view';
 import { computeWallpaperHash, loadWallpaperCache, storeWallpaperCache } from '@/lib/wallpaper-cache';
 import LifeView from '../wallpaper/life-view-enhanced';
+import StudentView from '../wallpaper/student-view-enhanced';
 import YearView from '../wallpaper/year-view-enhanced';
 
 // Import plugins directly for server-side execution
@@ -57,6 +59,10 @@ function getDateInTimezone(timezone: string = 'UTC'): Date {
 const rateLimitMap = new Map<string, { count: number; resetTime: number }>();
 const RATE_LIMIT_MAX = 100; // requests per window
 const RATE_LIMIT_WINDOW = 60 * 1000; // 1 minute
+const MIN_WIDTH = 300;
+const MAX_WIDTH = 3000;
+const MIN_HEIGHT = 300;
+const MAX_HEIGHT = 5000;
 
 function checkRateLimit(username: string): boolean {
   const now = Date.now();
@@ -180,9 +186,44 @@ export async function GET(
     if (!config.birthDate && config.viewMode === 'life') {
       return new Response('Birthdate is required for Life View. Please configure in dashboard.', { status: 400 });
     }
+
+    if (
+      config.viewMode === 'student' &&
+      (!config.studyStartDate || !config.universityName || !config.studyDurationYears)
+    ) {
+      return new Response('Student details are required for Student View. Please configure in dashboard.', { status: 400 });
+    }
     
     if (!config.device || !config.device.width || !config.device.height) {
       return new Response('Device configuration is required. Please configure in dashboard.', { status: 400 });
+    }
+
+    if (
+      !isSafeWallpaperDimension(config.device.width, MIN_WIDTH, MAX_WIDTH) ||
+      !isSafeWallpaperDimension(config.device.height, MIN_HEIGHT, MAX_HEIGHT)
+    ) {
+      return new Response('Saved device configuration is outside the supported image size limits.', { status: 400 });
+    }
+
+    let studentInput:
+      | { studyStartDate: string; universityName: string; studyDurationYears: number }
+      | null = null;
+
+    if (config.viewMode === 'student') {
+      const normalized = normalizeStudentViewInput({
+        studyStartDate: config.studyStartDate || '',
+        universityName: config.universityName || '',
+        studyDurationYears: config.studyDurationYears || '',
+      });
+
+      if (!normalized.ok) {
+        return new Response(`Invalid student view configuration: ${normalized.error}`, { status: 400 });
+      }
+
+      studentInput = normalized.value;
+      config.studyStartDate = studentInput.studyStartDate;
+      config.universityName = studentInput.universityName;
+      config.studyDurationYears = studentInput.studyDurationYears;
     }
 
     // Map of available built-in plugins
@@ -234,6 +275,9 @@ export async function GET(
           colors: config.colors,
           typography: config.typography,
           birthDate: config.birthDate,
+          studyStartDate: config.studyStartDate,
+          universityName: config.universityName,
+          studyDurationYears: config.studyDurationYears,
           viewMode: config.viewMode,
           timezone: userTimezone,
           currentDate: currentDate,
@@ -278,6 +322,13 @@ export async function GET(
       view = LifeView({
         ...viewProps,
         birthDate: config.birthDate,
+      });
+    } else if (config.viewMode === 'student') {
+      view = StudentView({
+        ...viewProps,
+        studyStartDate: studentInput?.studyStartDate || '',
+        universityName: studentInput?.universityName || 'University',
+        studyDurationYears: studentInput?.studyDurationYears || 4,
       });
     } else {
       view = YearView({

--- a/app/api/wallpaper/life-view-enhanced.tsx
+++ b/app/api/wallpaper/life-view-enhanced.tsx
@@ -1,7 +1,7 @@
 /**
  * Life View Component - Enhanced with Customization Support
  * 
- * Renders 4,160 dots representing 80 years of life (1 dot = 1 week).
+ * Renders 4,420 dots representing 85 years of life (1 dot = 1 week).
  * Now supports custom colors, typography, layout, text elements, and plugin additions.
  */
 
@@ -63,12 +63,12 @@ export default function LifeView({
   backgroundImage,
 }: LifeViewProps) {
   // Life Logic
-  const LIFE_EXPECTANCY_YEARS = 80;
+  const LIFE_EXPECTANCY_YEARS = 85;
   const birth = new Date(birthDate);
   const today = currentDate;
 
-  // Calculate total weeks (80 years × 52 weeks/year = 4,160 weeks)
-  const TOTAL_DOTS = 4160;
+  // Calculate total weeks (85 years × 52 weeks/year = 4,420 weeks)
+  const TOTAL_DOTS = 4420;
 
   const diffTime = Math.abs(today.getTime() - birth.getTime());
   const weeksLived = Math.min(Math.ceil(diffTime / (1000 * 60 * 60 * 24 * 7)), TOTAL_DOTS);

--- a/app/api/wallpaper/life-view.tsx
+++ b/app/api/wallpaper/life-view.tsx
@@ -13,14 +13,14 @@ export function LifeView({ width, height, birthDate }: LifeViewProps) {
     const FUTURE_COLOR = '#333333'; // Dark grey
 
     // Life Logic
-    const LIFE_EXPECTANCY_YEARS = 80;
+    const LIFE_EXPECTANCY_YEARS = 85;
     const birth = new Date(birthDate);
     const today = new Date();
 
     // Calculate total weeks
-    // 80 years * 52 weeks/year = 4160 weeks
+    // 85 years * 52 weeks/year = 4420 weeks
     // Each dot represents one week of life
-    const TOTAL_DOTS = 4160;
+    const TOTAL_DOTS = 4420;
 
     const diffTime = Math.abs(today.getTime() - birth.getTime());
     const weeksLived = Math.min(Math.ceil(diffTime / (1000 * 60 * 60 * 24 * 7)), TOTAL_DOTS);

--- a/app/api/wallpaper/route.tsx
+++ b/app/api/wallpaper/route.tsx
@@ -7,12 +7,55 @@ import { ImageResponse } from '@vercel/og';
 import { NextRequest } from 'next/server';
 import { YearView } from './year-view';
 import { LifeView } from './life-view';
+import { StudentView } from './student-view';
 import { logWallpaperEvent } from '@/lib/firebase-server';
+import { isSafeWallpaperDimension, normalizeStudentViewInput } from '@/lib/student-view';
 
 export const runtime = 'edge';
 
+const MIN_WIDTH = 300;
+const MAX_WIDTH = 3000;
+const MIN_HEIGHT = 300;
+const MAX_HEIGHT = 5000;
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_MAX = 45;
+const anonymousRateLimitMap = new Map<string, { count: number; resetTime: number }>();
+
+function getClientKey(request: NextRequest): string {
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  if (forwardedFor) {
+    return forwardedFor.split(',')[0].trim();
+  }
+  return request.headers.get('x-real-ip') || 'anonymous';
+}
+
+function checkAnonymousRateLimit(clientKey: string): boolean {
+  const now = Date.now();
+  const existing = anonymousRateLimitMap.get(clientKey);
+
+  if (!existing || now > existing.resetTime) {
+    anonymousRateLimitMap.set(clientKey, { count: 1, resetTime: now + RATE_LIMIT_WINDOW_MS });
+    return true;
+  }
+
+  if (existing.count >= RATE_LIMIT_MAX) {
+    return false;
+  }
+
+  existing.count += 1;
+  return true;
+}
+
 export async function GET(request: NextRequest) {
   try {
+    const clientKey = getClientKey(request);
+    if (!checkAnonymousRateLimit(clientKey)) {
+      return new Response('Rate limit exceeded. Please try again later.', {
+        status: 429,
+        headers: { 'Retry-After': '60' },
+      });
+    }
+
     const { searchParams } = request.nextUrl;
     const width = parseInt(searchParams.get('width') || '1170');
     const height = parseInt(searchParams.get('height') || '2532');
@@ -21,11 +64,48 @@ export async function GET(request: NextRequest) {
     const daysLayoutMode = searchParams.get('daysLayoutMode') === 'calendar' ? 'calendar' : 'continuous';
     const viewMode = searchParams.get('viewMode') || 'year';
     const birthDate = searchParams.get('birthDate') || '';
+    const rawStudyStartDate = searchParams.get('studyStartDate') || '';
+    const rawUniversityName = searchParams.get('universityName') || '';
+    const rawStudyDurationYears = searchParams.get('studyDurationYears') || '';
+
+    if (!isSafeWallpaperDimension(width, MIN_WIDTH, MAX_WIDTH) || !isSafeWallpaperDimension(height, MIN_HEIGHT, MAX_HEIGHT)) {
+      return new Response(`Invalid dimensions. Width must be ${MIN_WIDTH}-${MAX_WIDTH}px and height must be ${MIN_HEIGHT}-${MAX_HEIGHT}px.`, {
+        status: 400,
+      });
+    }
+
+    let studentInput:
+      | { studyStartDate: string; universityName: string; studyDurationYears: number }
+      | null = null;
+
+    if (viewMode === 'student') {
+      const normalized = normalizeStudentViewInput({
+        studyStartDate: rawStudyStartDate,
+        universityName: rawUniversityName,
+        studyDurationYears: rawStudyDurationYears,
+      });
+
+      if (!normalized.ok) {
+        return new Response(normalized.error, { status: 400 });
+      }
+
+      studentInput = normalized.value;
+    }
 
     let content;
 
     if (viewMode === 'life' && birthDate) {
       content = <LifeView width={width} height={height} birthDate={birthDate} />;
+    } else if (viewMode === 'student' && studentInput) {
+      content = (
+        <StudentView
+          width={width}
+          height={height}
+          studyStartDate={studentInput.studyStartDate}
+          universityName={studentInput.universityName}
+          studyDurationYears={studentInput.studyDurationYears}
+        />
+      );
     } else {
       // Default to Year View
       content = <YearView width={width} height={height} isMondayFirst={isMondayFirst} yearViewLayout={yearViewLayout} daysLayoutMode={daysLayoutMode} />;

--- a/app/api/wallpaper/route.tsx
+++ b/app/api/wallpaper/route.tsx
@@ -66,6 +66,7 @@ export async function GET(request: NextRequest) {
     const birthDate = searchParams.get('birthDate') || '';
     const rawStudyStartDate = searchParams.get('studyStartDate') || '';
     const rawUniversityName = searchParams.get('universityName') || '';
+    const rawGoalEndDate = searchParams.get('goalEndDate') || '';
     const rawStudyDurationYears = searchParams.get('studyDurationYears') || '';
 
     if (!isSafeWallpaperDimension(width, MIN_WIDTH, MAX_WIDTH) || !isSafeWallpaperDimension(height, MIN_HEIGHT, MAX_HEIGHT)) {
@@ -75,13 +76,14 @@ export async function GET(request: NextRequest) {
     }
 
     let studentInput:
-      | { studyStartDate: string; universityName: string; studyDurationYears: number }
+      | { studyStartDate: string; universityName: string; goalEndDate: string; studyDurationYears: number }
       | null = null;
 
     if (viewMode === 'student') {
       const normalized = normalizeStudentViewInput({
         studyStartDate: rawStudyStartDate,
         universityName: rawUniversityName,
+        goalEndDate: rawGoalEndDate,
         studyDurationYears: rawStudyDurationYears,
       });
 
@@ -103,7 +105,7 @@ export async function GET(request: NextRequest) {
           height={height}
           studyStartDate={studentInput.studyStartDate}
           universityName={studentInput.universityName}
-          studyDurationYears={studentInput.studyDurationYears}
+          goalEndDate={studentInput.goalEndDate}
         />
       );
     } else {

--- a/app/api/wallpaper/student-view-enhanced.tsx
+++ b/app/api/wallpaper/student-view-enhanced.tsx
@@ -87,34 +87,28 @@ export default function StudentView({
   const cols = Math.ceil(totalWeeks / rows);
 
   const aspectRatio = height / width;
-  const safeTop = height * (aspectRatio > 2.0 ? Math.max(layout.topPadding, 0.16) : layout.topPadding);
-  const safeBottom = height * layout.bottomPadding;
-  const adjustedSidePadding = aspectRatio > 2.0
-    ? Math.min(layout.sidePadding, 0.1)
-    : layout.sidePadding;
-  const sidePadding = width * adjustedSidePadding;
+  const sidePadding = width * (aspectRatio > 2.0 ? 0.12 : 0.1);
+  const contentCenterY = height * (aspectRatio > 2.0 ? 0.63 : 0.6);
 
-  const titleFontSize = Math.max(28, width * typography.fontSize * 1.15);
-  const metaFontSize = Math.max(16, titleFontSize * 0.58);
-  const footerFontSize = Math.max(16, width * typography.fontSize * 0.9);
-  const headerHeight = titleFontSize + metaFontSize + 36;
-  const footerHeight = typography.statsVisible ? footerFontSize + 28 : 0;
+  const titleFontSize = Math.max(24, width * typography.fontSize * 0.82);
+  const metaFontSize = Math.max(14, titleFontSize * 0.58);
+  const statsFontSize = Math.max(15, width * typography.fontSize * 0.7);
 
-  const availableWidth = width - sidePadding * 2;
-  const availableHeight = height - safeTop - safeBottom - headerHeight - footerHeight;
+  const previewGridWidth = Math.min(width * 0.62, width - sidePadding * 2);
+  const horizontalGap = Math.max(3, Math.floor(Math.max(layout.dotSpacing, 0.45) * 3));
+  const verticalGap = Math.max(8, Math.floor(Math.max(layout.dotSpacing, 0.5) * 7));
 
-  const horizontalGap = Math.max(1, Math.floor(Math.max(layout.dotSpacing, 0.35) * 4));
-  const verticalGap = Math.max(6, Math.floor(Math.max(layout.dotSpacing, 0.45) * 10));
-
-  const dotSizeFromWidth = (availableWidth - horizontalGap * (cols - 1)) / cols;
-  const dotSizeFromHeight = (availableHeight - verticalGap * (rows - 1)) / rows;
-  const dotSize = Math.max(2, Math.floor(Math.min(dotSizeFromWidth, dotSizeFromHeight, 18)));
+  const dotSizeFromWidth = (previewGridWidth - horizontalGap * (cols - 1)) / cols;
+  const dotSizeFromHeight = (height * 0.12 - verticalGap * (rows - 1)) / rows;
+  const dotSize = Math.max(3, Math.floor(Math.min(dotSizeFromWidth, dotSizeFromHeight, 14)));
 
   const gridWidth = cols * dotSize + (cols - 1) * horizontalGap;
   const gridHeight = rows * dotSize + (rows - 1) * verticalGap;
-  const startX = Math.max(sidePadding, (width - gridWidth) / 2);
-  const startY = safeTop + headerHeight + Math.max(0, (availableHeight - gridHeight) / 2);
-  const footerY = startY + gridHeight + 24;
+  const startX = (width - gridWidth) / 2;
+  const startY = contentCenterY - gridHeight / 2;
+  const titleY = startY - (titleFontSize + metaFontSize + 26);
+  const statsY = startY + gridHeight + 26;
+  const dateRowY = statsY + statsFontSize + 18;
 
   const dots = [];
   for (let index = 0; index < totalWeeks; index++) {
@@ -141,10 +135,11 @@ export default function StudentView({
   }
 
   const programLabel = `${safeDurationYears} year${safeDurationYears === 1 ? '' : 's'}`;
-  const metaLabel = `Started ${formatMonthYear(startDate)} | Ends ${formatMonthYear(graduationDate)} | ${programLabel}`;
+  const metaLabel = `Student Calendar`;
   const footerLabel = isComplete
     ? `Completed | Graduated ${formatMonthYear(graduationDate)}`
-    : `${progressPercent}% complete | ${weeksRemaining}w left | ${formatMonthYear(graduationDate)}`;
+    : `${weeksRemaining}w left | ${progressPercent}% complete`;
+  const dateRowLabel = `${formatMonthYear(startDate)} | ${programLabel} | ${formatMonthYear(graduationDate)}`;
 
   return (
     <div
@@ -152,6 +147,7 @@ export default function StudentView({
         width: '100%',
         height: '100%',
         backgroundColor: colors.background,
+        backgroundImage: 'radial-gradient(circle at top, rgba(255,255,255,0.06) 0%, rgba(0,0,0,0) 38%)',
         display: 'flex',
         flexDirection: 'column',
         position: 'relative',
@@ -177,13 +173,13 @@ export default function StudentView({
       <div
         style={{
           position: 'absolute',
-          top: `${safeTop}px`,
+          top: `${titleY}px`,
           left: `${sidePadding}px`,
           width: `${width - sidePadding * 2}px`,
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
-          gap: '10px',
+          gap: '6px',
           textAlign: 'center',
         }}
       >
@@ -192,6 +188,7 @@ export default function StudentView({
             fontSize: `${titleFontSize}px`,
             fontFamily: typography.fontFamily,
             color: colors.past,
+            maxWidth: `${width * 0.68}px`,
           }}
         >
           {universityName.trim()}
@@ -201,6 +198,8 @@ export default function StudentView({
             fontSize: `${metaFontSize}px`,
             fontFamily: typography.fontFamily,
             color: colors.text,
+            textTransform: 'uppercase',
+            letterSpacing: '0.28em',
           }}
         >
           {metaLabel}
@@ -219,23 +218,43 @@ export default function StudentView({
       </div>
 
       {typography.statsVisible && (
-        <div
-          style={{
-            position: 'absolute',
-            top: `${footerY}px`,
-            left: `${sidePadding}px`,
-            width: `${width - sidePadding * 2}px`,
-            display: 'flex',
-            justifyContent: 'center',
-            alignItems: 'center',
-            fontSize: `${footerFontSize}px`,
-            fontFamily: typography.fontFamily,
-            color: colors.text,
-            textAlign: 'center',
-          }}
-        >
-          {footerLabel}
-        </div>
+        <>
+          <div
+            style={{
+              position: 'absolute',
+              top: `${statsY}px`,
+              left: `${sidePadding}px`,
+              width: `${width - sidePadding * 2}px`,
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              fontSize: `${statsFontSize}px`,
+              fontFamily: typography.fontFamily,
+              color: colors.current,
+              textAlign: 'center',
+            }}
+          >
+            {footerLabel}
+          </div>
+
+          <div
+            style={{
+              position: 'absolute',
+              top: `${dateRowY}px`,
+              left: `${sidePadding}px`,
+              width: `${width - sidePadding * 2}px`,
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              fontSize: `${Math.max(12, statsFontSize * 0.85)}px`,
+              fontFamily: typography.fontFamily,
+              color: colors.text,
+              textAlign: 'center',
+            }}
+          >
+            {dateRowLabel}
+          </div>
+        </>
       )}
 
       {textElements.map((element) => {

--- a/app/api/wallpaper/student-view-enhanced.tsx
+++ b/app/api/wallpaper/student-view-enhanced.tsx
@@ -1,0 +1,303 @@
+import { CSSProperties } from 'react';
+import { PluginRenderElement, TextElement } from '@/lib/types';
+import { getAcademicGraduationDate } from '@/lib/student-view';
+
+interface StudentViewProps {
+  width: number;
+  height: number;
+  studyStartDate: string;
+  universityName: string;
+  studyDurationYears: number;
+  colors?: {
+    background: string;
+    past: string;
+    current: string;
+    future: string;
+    text: string;
+  };
+  typography?: {
+    fontFamily: string;
+    fontSize: number;
+    statsVisible: boolean;
+  };
+  layout?: {
+    topPadding: number;
+    bottomPadding: number;
+    sidePadding: number;
+    dotSpacing: number;
+  };
+  textElements?: TextElement[];
+  pluginElements?: PluginRenderElement[];
+  currentDate?: Date;
+  backgroundImage?: { url: string; opacity: number };
+}
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function formatMonthYear(date: Date): string {
+  return `${MONTHS[date.getMonth()]} ${date.getFullYear()}`;
+}
+
+export default function StudentView({
+  width,
+  height,
+  studyStartDate,
+  universityName,
+  studyDurationYears,
+  colors = {
+    background: '#1a1a1a',
+    past: '#FFFFFF',
+    current: '#FF6B35',
+    future: '#404040',
+    text: '#888888',
+  },
+  typography = {
+    fontFamily: 'monospace',
+    fontSize: 0.035,
+    statsVisible: true,
+  },
+  layout = {
+    topPadding: 0.18,
+    bottomPadding: 0.12,
+    sidePadding: 0.10,
+    dotSpacing: 0.7,
+  },
+  textElements = [],
+  pluginElements = [],
+  currentDate = new Date(),
+  backgroundImage,
+}: StudentViewProps) {
+  const startDate = new Date(studyStartDate);
+  const safeDurationYears = clamp(Math.round(studyDurationYears || 4), 1, 10);
+  const graduationDate = getAcademicGraduationDate(startDate, safeDurationYears);
+  const totalWeeks = Math.max(1, Math.ceil((graduationDate.getTime() - startDate.getTime()) / WEEK_MS));
+
+  const elapsedWeeksRaw = Math.floor((currentDate.getTime() - startDate.getTime()) / WEEK_MS);
+  const completedWeeks = clamp(elapsedWeeksRaw, 0, totalWeeks);
+  const weeksRemaining = Math.max(totalWeeks - completedWeeks, 0);
+  const progressPercent = Math.round((completedWeeks / totalWeeks) * 1000) / 10;
+  const isComplete = currentDate.getTime() >= graduationDate.getTime();
+
+  const rows = safeDurationYears;
+  const cols = Math.ceil(totalWeeks / rows);
+
+  const aspectRatio = height / width;
+  const safeTop = height * (aspectRatio > 2.0 ? Math.max(layout.topPadding, 0.16) : layout.topPadding);
+  const safeBottom = height * layout.bottomPadding;
+  const adjustedSidePadding = aspectRatio > 2.0
+    ? Math.min(layout.sidePadding, 0.1)
+    : layout.sidePadding;
+  const sidePadding = width * adjustedSidePadding;
+
+  const titleFontSize = Math.max(28, width * typography.fontSize * 1.15);
+  const metaFontSize = Math.max(16, titleFontSize * 0.58);
+  const footerFontSize = Math.max(16, width * typography.fontSize * 0.9);
+  const headerHeight = titleFontSize + metaFontSize + 36;
+  const footerHeight = typography.statsVisible ? footerFontSize + 28 : 0;
+
+  const availableWidth = width - sidePadding * 2;
+  const availableHeight = height - safeTop - safeBottom - headerHeight - footerHeight;
+
+  const horizontalGap = Math.max(1, Math.floor(Math.max(layout.dotSpacing, 0.35) * 4));
+  const verticalGap = Math.max(6, Math.floor(Math.max(layout.dotSpacing, 0.45) * 10));
+
+  const dotSizeFromWidth = (availableWidth - horizontalGap * (cols - 1)) / cols;
+  const dotSizeFromHeight = (availableHeight - verticalGap * (rows - 1)) / rows;
+  const dotSize = Math.max(2, Math.floor(Math.min(dotSizeFromWidth, dotSizeFromHeight, 18)));
+
+  const gridWidth = cols * dotSize + (cols - 1) * horizontalGap;
+  const gridHeight = rows * dotSize + (rows - 1) * verticalGap;
+  const startX = Math.max(sidePadding, (width - gridWidth) / 2);
+  const startY = safeTop + headerHeight + Math.max(0, (availableHeight - gridHeight) / 2);
+  const footerY = startY + gridHeight + 24;
+
+  const dots = [];
+  for (let index = 0; index < totalWeeks; index++) {
+    const row = Math.floor(index / cols);
+    const col = index % cols;
+    const isCurrent = !isComplete && index === completedWeeks;
+    const isPast = index < completedWeeks;
+    const color = isCurrent ? colors.current : isPast ? colors.past : colors.future;
+
+    dots.push(
+      <div
+        key={`student-dot-${index}`}
+        style={{
+          position: 'absolute',
+          left: `${startX + col * (dotSize + horizontalGap)}px`,
+          top: `${startY + row * (dotSize + verticalGap)}px`,
+          width: `${dotSize}px`,
+          height: `${dotSize}px`,
+          borderRadius: '50%',
+          backgroundColor: color,
+        }}
+      />
+    );
+  }
+
+  const programLabel = `${safeDurationYears} year${safeDurationYears === 1 ? '' : 's'}`;
+  const metaLabel = `Started ${formatMonthYear(startDate)} | Ends ${formatMonthYear(graduationDate)} | ${programLabel}`;
+  const footerLabel = isComplete
+    ? `Completed | Graduated ${formatMonthYear(graduationDate)}`
+    : `${progressPercent}% complete | ${weeksRemaining}w left | ${formatMonthYear(graduationDate)}`;
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        backgroundColor: colors.background,
+        display: 'flex',
+        flexDirection: 'column',
+        position: 'relative',
+      }}
+    >
+      {backgroundImage?.url && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={backgroundImage.url}
+          alt=""
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: '100%',
+            objectFit: 'cover',
+            opacity: backgroundImage.opacity ?? 0.1,
+          }}
+        />
+      )}
+
+      <div
+        style={{
+          position: 'absolute',
+          top: `${safeTop}px`,
+          left: `${sidePadding}px`,
+          width: `${width - sidePadding * 2}px`,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '10px',
+          textAlign: 'center',
+        }}
+      >
+        <div
+          style={{
+            fontSize: `${titleFontSize}px`,
+            fontFamily: typography.fontFamily,
+            color: colors.past,
+          }}
+        >
+          {universityName.trim()}
+        </div>
+        <div
+          style={{
+            fontSize: `${metaFontSize}px`,
+            fontFamily: typography.fontFamily,
+            color: colors.text,
+          }}
+        >
+          {metaLabel}
+        </div>
+      </div>
+
+      <div
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+        }}
+      >
+        {dots}
+      </div>
+
+      {typography.statsVisible && (
+        <div
+          style={{
+            position: 'absolute',
+            top: `${footerY}px`,
+            left: `${sidePadding}px`,
+            width: `${width - sidePadding * 2}px`,
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            fontSize: `${footerFontSize}px`,
+            fontFamily: typography.fontFamily,
+            color: colors.text,
+            textAlign: 'center',
+          }}
+        >
+          {footerLabel}
+        </div>
+      )}
+
+      {textElements.map((element) => {
+        if (!element.visible || element.content == null) return null;
+
+        const style: CSSProperties = {
+          position: 'absolute',
+          left: `${element.x}%`,
+          top: `${element.y}%`,
+          fontSize: `${element.fontSize || 16}px`,
+          fontFamily: element.fontFamily || typography.fontFamily,
+          color: element.color || colors.text,
+        };
+
+        const align = element.align || 'left';
+        if (align === 'center') {
+          style.transform = 'translate(-50%, -50%)';
+        } else if (align === 'right') {
+          style.transform = 'translate(-100%, -50%)';
+        } else {
+          style.transform = 'translateY(-50%)';
+        }
+
+        return (
+          <div key={element.id} style={style}>
+            {String(element.content).trim()}
+          </div>
+        );
+      })}
+
+      {pluginElements.map((element, index) => {
+        if (element.type === 'text' && element.content != null) {
+          const contentStr = String(element.content || '').trim();
+          if (!contentStr) return null;
+
+          const style: CSSProperties = {
+            position: 'absolute',
+            left: `${element.x}px`,
+            top: `${element.y}px`,
+            fontSize: `${element.fontSize || 16}px`,
+            color: element.color || colors.text,
+            fontFamily: element.fontFamily || typography.fontFamily,
+          };
+
+          if (element.align === 'center') {
+            style.transform = 'translateX(-50%)';
+          } else if (element.align === 'right') {
+            style.transform = 'translateX(-100%)';
+          }
+
+          if (typeof element.maxWidth === 'number') {
+            style.maxWidth = `${element.maxWidth}px`;
+          }
+
+          return (
+            <div key={`plugin-${index}`} style={style}>
+              {contentStr}
+            </div>
+          );
+        }
+        return null;
+      })}
+    </div>
+  );
+}

--- a/app/api/wallpaper/student-view-enhanced.tsx
+++ b/app/api/wallpaper/student-view-enhanced.tsx
@@ -1,13 +1,13 @@
 import { CSSProperties } from 'react';
 import { PluginRenderElement, TextElement } from '@/lib/types';
-import { getAcademicGraduationDate } from '@/lib/student-view';
+import { getGoalSpanYears } from '@/lib/student-view';
 
 interface StudentViewProps {
   width: number;
   height: number;
   studyStartDate: string;
   universityName: string;
-  studyDurationYears: number;
+  goalEndDate: string;
   colors?: {
     background: string;
     past: string;
@@ -33,14 +33,9 @@ interface StudentViewProps {
 }
 
 const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
-const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
-}
-
-function formatMonthYear(date: Date): string {
-  return `${MONTHS[date.getMonth()]} ${date.getFullYear()}`;
 }
 
 export default function StudentView({
@@ -48,7 +43,7 @@ export default function StudentView({
   height,
   studyStartDate,
   universityName,
-  studyDurationYears,
+  goalEndDate,
   colors = {
     background: '#1a1a1a',
     past: '#FFFFFF',
@@ -62,10 +57,10 @@ export default function StudentView({
     statsVisible: true,
   },
   layout = {
-    topPadding: 0.18,
-    bottomPadding: 0.12,
+    topPadding: 0.25,
+    bottomPadding: 0.14,
     sidePadding: 0.10,
-    dotSpacing: 0.7,
+    dotSpacing: 0.5,
   },
   textElements = [],
   pluginElements = [],
@@ -73,58 +68,66 @@ export default function StudentView({
   backgroundImage,
 }: StudentViewProps) {
   const startDate = new Date(studyStartDate);
-  const safeDurationYears = clamp(Math.round(studyDurationYears || 4), 1, 10);
-  const graduationDate = getAcademicGraduationDate(startDate, safeDurationYears);
-  const totalWeeks = Math.max(1, Math.ceil((graduationDate.getTime() - startDate.getTime()) / WEEK_MS));
-
+  const endDate = new Date(goalEndDate);
+  const totalWeeks = Math.max(1, Math.ceil((endDate.getTime() - startDate.getTime()) / WEEK_MS));
   const elapsedWeeksRaw = Math.floor((currentDate.getTime() - startDate.getTime()) / WEEK_MS);
   const completedWeeks = clamp(elapsedWeeksRaw, 0, totalWeeks);
   const weeksRemaining = Math.max(totalWeeks - completedWeeks, 0);
-  const progressPercent = Math.round((completedWeeks / totalWeeks) * 1000) / 10;
-  const isComplete = currentDate.getTime() >= graduationDate.getTime();
+  const progressPercent = Math.round((completedWeeks / totalWeeks) * 100);
+  const goalTitle = universityName.trim() || 'Your Goal';
 
-  const rows = safeDurationYears;
+  const rows = clamp(getGoalSpanYears(startDate, endDate), 1, 10);
   const cols = Math.ceil(totalWeeks / rows);
-
   const aspectRatio = height / width;
-  const sidePadding = width * (aspectRatio > 2.0 ? 0.12 : 0.1);
-  const contentCenterY = height * (aspectRatio > 2.0 ? 0.63 : 0.6);
 
-  const titleFontSize = Math.max(24, width * typography.fontSize * 0.82);
-  const metaFontSize = Math.max(14, titleFontSize * 0.58);
-  const statsFontSize = Math.max(15, width * typography.fontSize * 0.7);
+  const safeAreaTop = aspectRatio > 2.0
+    ? height * Math.max(layout.topPadding, 0.28)
+    : height * layout.topPadding;
+  const safeAreaBottom = height * layout.bottomPadding;
+  const adjustedSidePadding = aspectRatio > 2.1
+    ? Math.min(layout.sidePadding, 0.08)
+    : aspectRatio > 2.0
+      ? Math.min(layout.sidePadding, 0.09)
+      : layout.sidePadding;
+  const safeWidthPadding = width * adjustedSidePadding;
 
-  const previewGridWidth = Math.min(width * 0.62, width - sidePadding * 2);
-  const horizontalGap = Math.max(3, Math.floor(Math.max(layout.dotSpacing, 0.45) * 3));
-  const verticalGap = Math.max(8, Math.floor(Math.max(layout.dotSpacing, 0.5) * 7));
+  const availableWidth = width - safeWidthPadding * 2;
+  const availableHeight = height - safeAreaTop - safeAreaBottom;
+  const titleFontSize = Math.max(16, width * typography.fontSize * 0.9);
+  const footerFontSize = Math.max(15, width * typography.fontSize);
+  const titleSpace = titleFontSize * 2.2;
+  const footerSpace = typography.statsVisible ? footerFontSize * 3.1 : 0;
+  const gridAvailableHeight = Math.max(80, availableHeight - titleSpace - footerSpace);
 
-  const dotSizeFromWidth = (previewGridWidth - horizontalGap * (cols - 1)) / cols;
-  const dotSizeFromHeight = (height * 0.12 - verticalGap * (rows - 1)) / rows;
-  const dotSize = Math.max(3, Math.floor(Math.min(dotSizeFromWidth, dotSizeFromHeight, 14)));
+  const gap = Math.max(1, Math.floor(Math.max(layout.dotSpacing, 0.45) * 3));
+  const dotSizeFromWidth = (availableWidth - gap * (cols - 1)) / cols;
+  const dotSizeFromHeight = (gridAvailableHeight - gap * (rows - 1)) / rows;
+  const dotSize = Math.max(3, Math.floor(Math.min(dotSizeFromWidth, dotSizeFromHeight, 18)));
 
-  const gridWidth = cols * dotSize + (cols - 1) * horizontalGap;
-  const gridHeight = rows * dotSize + (rows - 1) * verticalGap;
-  const startX = (width - gridWidth) / 2;
-  const startY = contentCenterY - gridHeight / 2;
-  const titleY = startY - (titleFontSize + metaFontSize + 26);
-  const statsY = startY + gridHeight + 26;
-  const dateRowY = statsY + statsFontSize + 18;
+  const gridWidth = cols * dotSize + (cols - 1) * gap;
+  const gridHeight = rows * dotSize + (rows - 1) * gap;
+  const startX = Math.max(safeWidthPadding, (width - gridWidth) / 2);
+  const startY = safeAreaTop + Math.max(0, (gridAvailableHeight - gridHeight) / 2);
+  const titleY = Math.max(safeAreaTop * 0.8, startY - titleFontSize * 1.6);
+  const footerY = startY + gridHeight + footerFontSize * 1.7;
 
   const dots = [];
   for (let index = 0; index < totalWeeks; index++) {
     const row = Math.floor(index / cols);
     const col = index % cols;
-    const isCurrent = !isComplete && index === completedWeeks;
-    const isPast = index < completedWeeks;
-    const color = isCurrent ? colors.current : isPast ? colors.past : colors.future;
+    const color = index < completedWeeks
+      ? colors.past
+      : index === completedWeeks && completedWeeks < totalWeeks
+        ? colors.current
+        : colors.future;
 
     dots.push(
       <div
-        key={`student-dot-${index}`}
+        key={`goal-dot-${index}`}
         style={{
           position: 'absolute',
-          left: `${startX + col * (dotSize + horizontalGap)}px`,
-          top: `${startY + row * (dotSize + verticalGap)}px`,
+          left: `${startX + col * (dotSize + gap)}px`,
+          top: `${startY + row * (dotSize + gap)}px`,
           width: `${dotSize}px`,
           height: `${dotSize}px`,
           borderRadius: '50%',
@@ -134,20 +137,12 @@ export default function StudentView({
     );
   }
 
-  const programLabel = `${safeDurationYears} year${safeDurationYears === 1 ? '' : 's'}`;
-  const metaLabel = `Goal Calendar`;
-  const footerLabel = isComplete
-    ? `Completed | Graduated ${formatMonthYear(graduationDate)}`
-    : `${weeksRemaining}w left | ${progressPercent}% complete`;
-  const dateRowLabel = `${formatMonthYear(startDate)} | ${programLabel} | ${formatMonthYear(graduationDate)}`;
-
   return (
     <div
       style={{
         width: '100%',
         height: '100%',
         backgroundColor: colors.background,
-        backgroundImage: 'radial-gradient(circle at top, rgba(255,255,255,0.06) 0%, rgba(0,0,0,0) 38%)',
         display: 'flex',
         flexDirection: 'column',
         position: 'relative',
@@ -174,87 +169,40 @@ export default function StudentView({
         style={{
           position: 'absolute',
           top: `${titleY}px`,
-          left: `${sidePadding}px`,
-          width: `${width - sidePadding * 2}px`,
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: '6px',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          maxWidth: `${width * 0.72}px`,
+          fontSize: `${titleFontSize}px`,
+          fontFamily: typography.fontFamily,
+          color: colors.text,
           textAlign: 'center',
         }}
       >
-        <div
-          style={{
-            fontSize: `${titleFontSize}px`,
-            fontFamily: typography.fontFamily,
-            color: colors.past,
-            maxWidth: `${width * 0.68}px`,
-          }}
-        >
-          {universityName.trim()}
-        </div>
-        <div
-          style={{
-            fontSize: `${metaFontSize}px`,
-            fontFamily: typography.fontFamily,
-            color: colors.text,
-            textTransform: 'uppercase',
-            letterSpacing: '0.28em',
-          }}
-        >
-          {metaLabel}
-        </div>
+        {goalTitle}
       </div>
 
-      <div
-        style={{
-          position: 'relative',
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-        }}
-      >
+      <div style={{ display: 'flex', position: 'relative', width: '100%', height: '100%' }}>
         {dots}
       </div>
 
       {typography.statsVisible && (
-        <>
-          <div
-            style={{
-              position: 'absolute',
-              top: `${statsY}px`,
-              left: `${sidePadding}px`,
-              width: `${width - sidePadding * 2}px`,
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              fontSize: `${statsFontSize}px`,
-              fontFamily: typography.fontFamily,
-              color: colors.current,
-              textAlign: 'center',
-            }}
-          >
-            {footerLabel}
-          </div>
-
-          <div
-            style={{
-              position: 'absolute',
-              top: `${dateRowY}px`,
-              left: `${sidePadding}px`,
-              width: `${width - sidePadding * 2}px`,
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              fontSize: `${Math.max(12, statsFontSize * 0.85)}px`,
-              fontFamily: typography.fontFamily,
-              color: colors.text,
-              textAlign: 'center',
-            }}
-          >
-            {dateRowLabel}
-          </div>
-        </>
+        <div
+          style={{
+            position: 'absolute',
+            top: `${footerY}px`,
+            left: '0px',
+            width: '100%',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            fontSize: `${footerFontSize}px`,
+            fontFamily: typography.fontFamily,
+          }}
+        >
+          <span style={{ color: colors.current }}>{weeksRemaining}w left</span>
+          <span style={{ color: colors.text, margin: '0px 8px' }}>·</span>
+          <span style={{ color: colors.text }}>{progressPercent}%</span>
+        </div>
       )}
 
       {textElements.map((element) => {

--- a/app/api/wallpaper/student-view-enhanced.tsx
+++ b/app/api/wallpaper/student-view-enhanced.tsx
@@ -135,7 +135,7 @@ export default function StudentView({
   }
 
   const programLabel = `${safeDurationYears} year${safeDurationYears === 1 ? '' : 's'}`;
-  const metaLabel = `Student Calendar`;
+  const metaLabel = `Goal Calendar`;
   const footerLabel = isComplete
     ? `Completed | Graduated ${formatMonthYear(graduationDate)}`
     : `${weeksRemaining}w left | ${progressPercent}% complete`;

--- a/app/api/wallpaper/student-view.tsx
+++ b/app/api/wallpaper/student-view.tsx
@@ -5,7 +5,7 @@ interface StudentViewProps {
   height: number;
   studyStartDate: string;
   universityName: string;
-  studyDurationYears: number;
+  goalEndDate: string;
 }
 
 export function StudentView(props: StudentViewProps) {

--- a/app/api/wallpaper/student-view.tsx
+++ b/app/api/wallpaper/student-view.tsx
@@ -1,0 +1,13 @@
+import StudentViewEnhanced from './student-view-enhanced';
+
+interface StudentViewProps {
+  width: number;
+  height: number;
+  studyStartDate: string;
+  universityName: string;
+  studyDurationYears: number;
+}
+
+export function StudentView(props: StudentViewProps) {
+  return <StudentViewEnhanced {...props} />;
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -12,6 +12,7 @@ import { saveUserProfile, saveUserConfig, isUsernameAvailable, getUserConfigByUs
 import { UserConfig, DeviceModel, ViewMode, Plugin, PluginConfig, TextElement, DaysLayoutMode, BackgroundImage } from '@/lib/types';
 import ViewModeToggle from '@/components/ViewModeToggle';
 import BirthDateInput from '@/components/BirthDateInput';
+import StudentDetailsInput from '@/components/StudentDetailsInput';
 import DeviceSelector from '@/components/DeviceSelector';
 import ThemeColorPicker from '@/components/ThemeColorPicker';
 import PluginMarketplace from '@/components/PluginMarketplace';
@@ -42,6 +43,9 @@ export default function DashboardPage() {
   // Wallpaper config
   const [viewMode, setViewMode] = useState<ViewMode>('life');
   const [birthDate, setBirthDate] = useState('');
+  const [studyStartDate, setStudyStartDate] = useState('');
+  const [universityName, setUniversityName] = useState('');
+  const [studyDurationYears, setStudyDurationYears] = useState('');
   const [selectedDevice, setSelectedDevice] = useState<DeviceModel | null>(null);
   const [isMondayFirst, setIsMondayFirst] = useState(false);
   const [yearViewLayout, setYearViewLayout] = useState<'months' | 'days'>('months');
@@ -108,9 +112,11 @@ export default function DashboardPage() {
   const saveStatusTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   // Calculate if config is complete (needed before useEffects)
-  const isConfigComplete = viewMode === 'year' 
-    ? selectedDevice !== null 
-    : (birthDate && selectedDevice);
+  const isConfigComplete = viewMode === 'year'
+    ? selectedDevice !== null
+    : viewMode === 'life'
+      ? Boolean(birthDate && selectedDevice)
+      : Boolean(studyStartDate && universityName.trim() && studyDurationYears && selectedDevice);
 
   useEffect(() => {
     setMounted(true);
@@ -150,6 +156,9 @@ export default function DashboardPage() {
       backgroundImage: JSON.stringify(backgroundImage),
       viewMode,
       birthDate,
+      studyStartDate,
+      universityName: universityName.trim(),
+      studyDurationYears,
       isMondayFirst,
       yearViewLayout,
       daysLayoutMode,
@@ -166,6 +175,9 @@ export default function DashboardPage() {
       backgroundImage: JSON.stringify(config.backgroundImage ?? null),
       viewMode: config.viewMode,
       birthDate: config.birthDate,
+      studyStartDate: config.studyStartDate,
+      universityName: config.universityName,
+      studyDurationYears: config.studyDurationYears != null ? String(config.studyDurationYears) : '',
       isMondayFirst: config.isMondayFirst,
       yearViewLayout: config.yearViewLayout,
       daysLayoutMode: config.daysLayoutMode,
@@ -207,7 +219,7 @@ export default function DashboardPage() {
         clearTimeout(saveTimeoutRef.current);
       }
     };
-  }, [colors, fontFamily, fontSize, statsVisible, layout, plugins, textElements, backgroundImage, viewMode, birthDate, isMondayFirst, yearViewLayout, daysLayoutMode, timezone, selectedDevice, config, isConfigComplete]);
+  }, [colors, fontFamily, fontSize, statsVisible, layout, plugins, textElements, backgroundImage, viewMode, birthDate, studyStartDate, universityName, studyDurationYears, isMondayFirst, yearViewLayout, daysLayoutMode, timezone, selectedDevice, config, isConfigComplete]);
 
   const loadUserConfig = async (username: string) => {
     const { data } = await getUserConfigByUsername(username);
@@ -216,6 +228,9 @@ export default function DashboardPage() {
       setConfig(cfg);
       setViewMode(cfg.viewMode || 'life');
       setBirthDate(cfg.birthDate || '');
+      setStudyStartDate(cfg.studyStartDate || '');
+      setUniversityName(cfg.universityName || '');
+      setStudyDurationYears(cfg.studyDurationYears ? String(cfg.studyDurationYears) : '');
       setIsMondayFirst(cfg.isMondayFirst || false);
       setYearViewLayout(cfg.yearViewLayout || 'months');
       setDaysLayoutMode(cfg.daysLayoutMode || 'continuous');
@@ -290,6 +305,9 @@ export default function DashboardPage() {
         plugins: [],
         viewMode: viewMode,
         birthDate: birthDate,
+        studyStartDate: studyStartDate,
+        universityName: universityName.trim(),
+        studyDurationYears: studyDurationYears ? parseInt(studyDurationYears, 10) : undefined,
         isMondayFirst: isMondayFirst,
         yearViewLayout: yearViewLayout,
         daysLayoutMode: daysLayoutMode,
@@ -432,6 +450,9 @@ export default function DashboardPage() {
       layout,
       viewMode,
       birthDate,
+      studyStartDate,
+      universityName: universityName.trim(),
+      studyDurationYears: studyDurationYears ? parseInt(studyDurationYears, 10) : undefined,
       isMondayFirst,
       yearViewLayout,
       daysLayoutMode,
@@ -469,6 +490,9 @@ export default function DashboardPage() {
         if (imported.layout) setLayout(imported.layout);
         if (imported.viewMode) setViewMode(imported.viewMode);
         if (imported.birthDate) setBirthDate(imported.birthDate);
+        if (imported.studyStartDate) setStudyStartDate(imported.studyStartDate);
+        if (imported.universityName) setUniversityName(imported.universityName);
+        if (imported.studyDurationYears !== undefined) setStudyDurationYears(String(imported.studyDurationYears));
         if (imported.isMondayFirst !== undefined) setIsMondayFirst(imported.isMondayFirst);
         if (imported.yearViewLayout) setYearViewLayout(imported.yearViewLayout);
         if (imported.daysLayoutMode) setDaysLayoutMode(imported.daysLayoutMode);
@@ -522,6 +546,9 @@ export default function DashboardPage() {
         userId: user.uid,
         username: userProfile.username,
         birthDate,
+        studyStartDate,
+        universityName: universityName.trim(),
+        studyDurationYears: studyDurationYears ? parseInt(studyDurationYears, 10) : undefined,
         viewMode,
         device: selectedDevice ? {
           brand: selectedDevice.brand,
@@ -570,6 +597,9 @@ export default function DashboardPage() {
       userId: user.uid,
       username: userProfile.username,
       birthDate,
+      studyStartDate,
+      universityName: universityName.trim(),
+      studyDurationYears: studyDurationYears ? parseInt(studyDurationYears, 10) : undefined,
       viewMode,
       device: selectedDevice ? {
         brand: selectedDevice.brand,
@@ -902,6 +932,17 @@ export default function DashboardPage() {
             <div className="space-y-2">
               <BirthDateInput value={birthDate} onChange={setBirthDate} />
             </div>
+          )}
+
+          {viewMode === 'student' && (
+            <StudentDetailsInput
+              studyStartDate={studyStartDate}
+              universityName={universityName}
+              studyDurationYears={studyDurationYears}
+              onStudyStartDateChange={setStudyStartDate}
+              onUniversityNameChange={setUniversityName}
+              onStudyDurationYearsChange={setStudyDurationYears}
+            />
           )}
 
           {/* Device Selector */}
@@ -1545,6 +1586,9 @@ export default function DashboardPage() {
           <div className="bg-red-900/20 border border-red-500/50 rounded-lg px-4 py-2 shadow-lg">
             <div className="text-xs text-red-400">
               {viewMode === 'life' && !birthDate && '⚠ Please enter your birth date'}
+              {viewMode === 'student' && !studyStartDate && '⚠ Please enter your study start date'}
+              {viewMode === 'student' && studyStartDate && !universityName.trim() && '⚠ Please enter your university'}
+              {viewMode === 'student' && studyStartDate && universityName.trim() && !studyDurationYears && '⚠ Please enter your study duration'}
               {!selectedDevice && '⚠ Please select a device'}
             </div>
           </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -104,6 +104,8 @@ export default function DashboardPage() {
   // Auto-save with debouncing
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [autoSaving, setAutoSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
+  const saveStatusTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   // Calculate if config is complete (needed before useEffects)
   const isConfigComplete = viewMode === 'year' 
@@ -184,7 +186,16 @@ export default function DashboardPage() {
       // Set new timeout for auto-save
       saveTimeoutRef.current = setTimeout(() => {
         setAutoSaving(true);
-        saveConfig().finally(() => {
+        setSaveStatus('saving');
+        saveConfig().then(() => {
+          setSaveStatus('saved');
+          if (saveStatusTimerRef.current) clearTimeout(saveStatusTimerRef.current);
+          saveStatusTimerRef.current = setTimeout(() => setSaveStatus('idle'), 3000);
+        }).catch(() => {
+          setSaveStatus('error');
+          if (saveStatusTimerRef.current) clearTimeout(saveStatusTimerRef.current);
+          saveStatusTimerRef.current = setTimeout(() => setSaveStatus('idle'), 4000);
+        }).finally(() => {
           setAutoSaving(false);
         });
       }, 2000); // 2 seconds after last change
@@ -667,6 +678,13 @@ export default function DashboardPage() {
               </div>
             )}
 
+            {hasUnsavedChanges && (
+              <div className="flex items-center gap-2 text-xs text-yellow-500 px-1">
+                <div className="w-1.5 h-1.5 bg-yellow-500 rounded-full flex-shrink-0" />
+                Unsaved changes will be saved automatically once setup is complete.
+              </div>
+            )}
+
             <button
               onClick={handleSaveUsername}
               disabled={!usernameAvailable || savingUsername}
@@ -690,6 +708,30 @@ export default function DashboardPage() {
           <div>
             <h1 className="text-sm tracking-widest uppercase">Dashboard</h1>
             <code className="text-xs text-neutral-500">/api/{userProfile.username}</code>
+          </div>
+          {/* Save-status widget */}
+          <div className={`flex items-center gap-1.5 text-xs transition-opacity duration-300 ${saveStatus === 'idle' && !hasUnsavedChanges ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}>
+            {saveStatus === 'saving' ? (
+              <>
+                <div className="w-1.5 h-1.5 bg-blue-500 rounded-full animate-pulse" />
+                <span className="text-neutral-400">Saving...</span>
+              </>
+            ) : saveStatus === 'saved' ? (
+              <>
+                <div className="w-1.5 h-1.5 bg-green-500 rounded-full" />
+                <span className="text-green-500">All changes saved</span>
+              </>
+            ) : saveStatus === 'error' ? (
+              <>
+                <div className="w-1.5 h-1.5 bg-red-500 rounded-full" />
+                <span className="text-red-400">Save failed</span>
+              </>
+            ) : hasUnsavedChanges ? (
+              <>
+                <div className="w-1.5 h-1.5 bg-yellow-500 rounded-full" />
+                <span className="text-yellow-500">Unsaved changes</span>
+              </>
+            ) : null}
           </div>
         </div>
         <div className="flex items-center gap-4">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -20,6 +20,7 @@ import TextElementsEditor from '@/components/TextElementsEditor';
 import BackgroundPicker from '@/components/BackgroundPicker';
 import { PRESET_THEMES, getThemeByName, Theme } from '@/lib/themes';
 import { seedExamplePlugins } from '@/lib/seed-plugins';
+import { deriveGoalEndDateFromDuration } from '@/lib/student-view';
 
 /** Returns remaining days until expiry, or null if no expiry. Negative = expired. */
 function getDaysRemaining(planExpiresAt: any): number | null {
@@ -45,7 +46,7 @@ export default function DashboardPage() {
   const [birthDate, setBirthDate] = useState('');
   const [studyStartDate, setStudyStartDate] = useState('');
   const [universityName, setUniversityName] = useState('');
-  const [studyDurationYears, setStudyDurationYears] = useState('');
+  const [goalEndDate, setGoalEndDate] = useState('');
   const [selectedDevice, setSelectedDevice] = useState<DeviceModel | null>(null);
   const [isMondayFirst, setIsMondayFirst] = useState(false);
   const [yearViewLayout, setYearViewLayout] = useState<'months' | 'days'>('months');
@@ -116,7 +117,7 @@ export default function DashboardPage() {
     ? selectedDevice !== null
     : viewMode === 'life'
       ? Boolean(birthDate && selectedDevice)
-      : Boolean(studyStartDate && universityName.trim() && studyDurationYears && selectedDevice);
+      : Boolean(studyStartDate && universityName.trim() && goalEndDate && selectedDevice);
 
   useEffect(() => {
     setMounted(true);
@@ -158,7 +159,7 @@ export default function DashboardPage() {
       birthDate,
       studyStartDate,
       universityName: universityName.trim(),
-      studyDurationYears,
+      goalEndDate,
       isMondayFirst,
       yearViewLayout,
       daysLayoutMode,
@@ -177,7 +178,7 @@ export default function DashboardPage() {
       birthDate: config.birthDate,
       studyStartDate: config.studyStartDate,
       universityName: config.universityName,
-      studyDurationYears: config.studyDurationYears != null ? String(config.studyDurationYears) : '',
+      goalEndDate: config.goalEndDate || deriveGoalEndDateFromDuration(config.studyStartDate || '', config.studyDurationYears),
       isMondayFirst: config.isMondayFirst,
       yearViewLayout: config.yearViewLayout,
       daysLayoutMode: config.daysLayoutMode,
@@ -219,7 +220,7 @@ export default function DashboardPage() {
         clearTimeout(saveTimeoutRef.current);
       }
     };
-  }, [colors, fontFamily, fontSize, statsVisible, layout, plugins, textElements, backgroundImage, viewMode, birthDate, studyStartDate, universityName, studyDurationYears, isMondayFirst, yearViewLayout, daysLayoutMode, timezone, selectedDevice, config, isConfigComplete]);
+  }, [colors, fontFamily, fontSize, statsVisible, layout, plugins, textElements, backgroundImage, viewMode, birthDate, studyStartDate, universityName, goalEndDate, isMondayFirst, yearViewLayout, daysLayoutMode, timezone, selectedDevice, config, isConfigComplete]);
 
   const loadUserConfig = async (username: string) => {
     const { data } = await getUserConfigByUsername(username);
@@ -230,7 +231,11 @@ export default function DashboardPage() {
       setBirthDate(cfg.birthDate || '');
       setStudyStartDate(cfg.studyStartDate || '');
       setUniversityName(cfg.universityName || '');
-      setStudyDurationYears(cfg.studyDurationYears ? String(cfg.studyDurationYears) : '');
+      setGoalEndDate(
+        cfg.goalEndDate ||
+        deriveGoalEndDateFromDuration(cfg.studyStartDate || '', cfg.studyDurationYears) ||
+        ''
+      );
       setIsMondayFirst(cfg.isMondayFirst || false);
       setYearViewLayout(cfg.yearViewLayout || 'months');
       setDaysLayoutMode(cfg.daysLayoutMode || 'continuous');
@@ -307,7 +312,7 @@ export default function DashboardPage() {
         birthDate: birthDate,
         studyStartDate: studyStartDate,
         universityName: universityName.trim(),
-        studyDurationYears: studyDurationYears ? parseInt(studyDurationYears, 10) : undefined,
+        goalEndDate: goalEndDate,
         isMondayFirst: isMondayFirst,
         yearViewLayout: yearViewLayout,
         daysLayoutMode: daysLayoutMode,
@@ -452,7 +457,7 @@ export default function DashboardPage() {
       birthDate,
       studyStartDate,
       universityName: universityName.trim(),
-      studyDurationYears: studyDurationYears ? parseInt(studyDurationYears, 10) : undefined,
+      goalEndDate,
       isMondayFirst,
       yearViewLayout,
       daysLayoutMode,
@@ -492,7 +497,11 @@ export default function DashboardPage() {
         if (imported.birthDate) setBirthDate(imported.birthDate);
         if (imported.studyStartDate) setStudyStartDate(imported.studyStartDate);
         if (imported.universityName) setUniversityName(imported.universityName);
-        if (imported.studyDurationYears !== undefined) setStudyDurationYears(String(imported.studyDurationYears));
+        if (imported.goalEndDate !== undefined) {
+          setGoalEndDate(imported.goalEndDate);
+        } else if (imported.studyDurationYears !== undefined) {
+          setGoalEndDate(deriveGoalEndDateFromDuration(imported.studyStartDate || '', imported.studyDurationYears));
+        }
         if (imported.isMondayFirst !== undefined) setIsMondayFirst(imported.isMondayFirst);
         if (imported.yearViewLayout) setYearViewLayout(imported.yearViewLayout);
         if (imported.daysLayoutMode) setDaysLayoutMode(imported.daysLayoutMode);
@@ -548,7 +557,7 @@ export default function DashboardPage() {
         birthDate,
         studyStartDate,
         universityName: universityName.trim(),
-        studyDurationYears: studyDurationYears ? parseInt(studyDurationYears, 10) : undefined,
+        goalEndDate,
         viewMode,
         device: selectedDevice ? {
           brand: selectedDevice.brand,
@@ -599,7 +608,7 @@ export default function DashboardPage() {
       birthDate,
       studyStartDate,
       universityName: universityName.trim(),
-      studyDurationYears: studyDurationYears ? parseInt(studyDurationYears, 10) : undefined,
+      goalEndDate,
       viewMode,
       device: selectedDevice ? {
         brand: selectedDevice.brand,
@@ -938,11 +947,11 @@ export default function DashboardPage() {
             <StudentDetailsInput
               studyStartDate={studyStartDate}
               universityName={universityName}
-              studyDurationYears={studyDurationYears}
+              goalEndDate={goalEndDate}
               selectedDeviceLabel={selectedDevice?.model || ''}
               onStudyStartDateChange={setStudyStartDate}
               onUniversityNameChange={setUniversityName}
-              onStudyDurationYearsChange={setStudyDurationYears}
+              onGoalEndDateChange={setGoalEndDate}
             />
           )}
 
@@ -1589,7 +1598,7 @@ export default function DashboardPage() {
               {viewMode === 'life' && !birthDate && '⚠ Please enter your birth date'}
               {viewMode === 'student' && !studyStartDate && '⚠ Please enter your study start date'}
               {viewMode === 'student' && studyStartDate && !universityName.trim() && '⚠ Please enter your university'}
-              {viewMode === 'student' && studyStartDate && universityName.trim() && !studyDurationYears && '⚠ Please enter your study duration'}
+              {viewMode === 'student' && studyStartDate && universityName.trim() && !goalEndDate && '⚠ Please enter your goal end date'}
               {!selectedDevice && '⚠ Please select a device'}
             </div>
           </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -939,6 +939,7 @@ export default function DashboardPage() {
               studyStartDate={studyStartDate}
               universityName={universityName}
               studyDurationYears={studyDurationYears}
+              selectedDeviceLabel={selectedDevice?.model || ''}
               onStudyStartDateChange={setStudyStartDate}
               onUniversityNameChange={setUniversityName}
               onStudyDurationYearsChange={setStudyDurationYears}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,9 +6,10 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { UserProfile, DeviceModel } from '@/lib/types';
+import { UserProfile, DeviceModel, ViewMode } from '@/lib/types';
 import DeviceSelector from '@/components/DeviceSelector';
 import BirthDateInput from '@/components/BirthDateInput';
+import StudentDetailsInput from '@/components/StudentDetailsInput';
 import ViewModeToggle from '@/components/ViewModeToggle';
 import SetupInstructions from '@/components/SetupInstructions';
 import AuthButton from '@/components/AuthButton';
@@ -18,8 +19,11 @@ const THEME_COLOR = 'FFFFFF'; // White for minimalist dark theme
 
 export default function Home() {
   const [birthDate, setBirthDate] = useState('');
+  const [studyStartDate, setStudyStartDate] = useState('');
+  const [universityName, setUniversityName] = useState('');
+  const [studyDurationYears, setStudyDurationYears] = useState('');
   const [selectedDevice, setSelectedDevice] = useState<DeviceModel | null>(null);
-  const [viewMode, setViewMode] = useState<'year' | 'life'>('life');
+  const [viewMode, setViewMode] = useState<ViewMode>('life');
   const [isMondayFirst, setIsMondayFirst] = useState(false);
   const [yearViewLayout, setYearViewLayout] = useState<'months' | 'days'>('months');
   const [daysLayoutMode, setDaysLayoutMode] = useState<'calendar' | 'continuous'>('continuous');
@@ -34,6 +38,9 @@ export default function Home() {
       if (savedProfile) {
         const profile: UserProfile = JSON.parse(savedProfile);
         setBirthDate(profile.birthDate);
+        setStudyStartDate(profile.studyStartDate || '');
+        setUniversityName(profile.universityName || '');
+        setStudyDurationYears(profile.studyDurationYears ? String(profile.studyDurationYears) : '');
         if (profile.viewMode) setViewMode(profile.viewMode);
         if (profile.isMondayFirst !== undefined) setIsMondayFirst(profile.isMondayFirst);
         if ((profile as any).yearViewLayout) setYearViewLayout((profile as any).yearViewLayout);
@@ -55,10 +62,19 @@ export default function Home() {
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    
-    if (birthDate && selectedDevice) {
-      const profile: any = {
-        birthDate,
+
+    const canSaveProfile = selectedDevice !== null && (
+      viewMode === 'year' ||
+      (viewMode === 'life' && Boolean(birthDate)) ||
+      (viewMode === 'student' && Boolean(studyStartDate) && Boolean(universityName.trim()) && Boolean(studyDurationYears))
+    );
+
+    if (canSaveProfile && selectedDevice) {
+        const profile: any = {
+          birthDate,
+          studyStartDate,
+          universityName: universityName.trim(),
+          studyDurationYears: studyDurationYears ? parseInt(studyDurationYears, 10) : undefined,
         themeColor: THEME_COLOR,
         device: {
           brand: selectedDevice.brand,
@@ -78,11 +94,12 @@ export default function Home() {
         console.error('Failed to save profile:', error);
       }
     }
-  }, [birthDate, selectedDevice, viewMode, isMondayFirst, yearViewLayout, daysLayoutMode]);
+  }, [birthDate, studyStartDate, universityName, studyDurationYears, selectedDevice, viewMode, isMondayFirst, yearViewLayout, daysLayoutMode]);
 
   const generateWallpaperUrl = () => {
     if (!selectedDevice || !selectedDevice.width || !selectedDevice.height) return;
     if (viewMode === 'life' && !birthDate) return;
+    if (viewMode === 'student' && (!studyStartDate || !universityName.trim() || !studyDurationYears)) return;
 
     const params = new URLSearchParams({
       themeColor: THEME_COLOR,
@@ -93,6 +110,12 @@ export default function Home() {
 
     if (viewMode === 'life' && birthDate) {
       params.append('birthDate', birthDate);
+    }
+
+    if (viewMode === 'student') {
+      params.append('studyStartDate', studyStartDate);
+      params.append('universityName', universityName.trim());
+      params.append('studyDurationYears', studyDurationYears);
     }
     
     if (viewMode === 'year') {
@@ -118,7 +141,7 @@ export default function Home() {
     if (isFormComplete && !wallpaperUrl) {
       generateWallpaperUrl();
     }
-  }, [selectedDevice, birthDate, viewMode, isMondayFirst, yearViewLayout, daysLayoutMode]);
+  }, [selectedDevice, birthDate, studyStartDate, universityName, studyDurationYears, viewMode, isMondayFirst, yearViewLayout, daysLayoutMode]);
 
   const copyToClipboard = async () => {
     try {
@@ -130,7 +153,11 @@ export default function Home() {
     }
   };
 
-  const isFormComplete = viewMode === 'year' ? selectedDevice !== null : (birthDate && selectedDevice);
+  const isFormComplete = viewMode === 'year'
+    ? selectedDevice !== null
+    : viewMode === 'life'
+      ? Boolean(birthDate && selectedDevice)
+      : Boolean(studyStartDate && universityName.trim() && studyDurationYears && selectedDevice);
 
   return (
     <main className="min-h-screen flex flex-col items-center justify-between p-6 selection:bg-white selection:text-black relative">
@@ -257,6 +284,17 @@ export default function Home() {
           <div className="space-y-6">
             {viewMode === 'life' && (
               <BirthDateInput value={birthDate} onChange={setBirthDate} />
+            )}
+
+            {viewMode === 'student' && (
+              <StudentDetailsInput
+                studyStartDate={studyStartDate}
+                universityName={universityName}
+                studyDurationYears={studyDurationYears}
+                onStudyStartDateChange={setStudyStartDate}
+                onUniversityNameChange={setUniversityName}
+                onStudyDurationYearsChange={setStudyDurationYears}
+              />
             )}
 
             <DeviceSelector

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -291,6 +291,7 @@ export default function Home() {
                 studyStartDate={studyStartDate}
                 universityName={universityName}
                 studyDurationYears={studyDurationYears}
+                selectedDeviceLabel={selectedDevice?.model || ''}
                 onStudyStartDateChange={setStudyStartDate}
                 onUniversityNameChange={setUniversityName}
                 onStudyDurationYearsChange={setStudyDurationYears}
@@ -340,10 +341,13 @@ export default function Home() {
                 href={wallpaperUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-xs text-neutral-500 hover:text-white transition-colors border-b border-transparent hover:border-white pb-0.5"
+                className={viewMode === 'student'
+                  ? 'block w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-4 text-sm font-medium uppercase tracking-[0.22em] text-white transition-colors hover:bg-white/10'
+                  : 'text-xs text-neutral-500 hover:text-white transition-colors border-b border-transparent hover:border-white pb-0.5'
+                }
                 aria-label="Open wallpaper preview in new tab"
               >
-                Preview Wallpaper
+                {viewMode === 'student' ? 'Install' : 'Preview Wallpaper'}
               </a>
             </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,9 +10,11 @@ import { UserProfile, DeviceModel, ViewMode } from '@/lib/types';
 import DeviceSelector from '@/components/DeviceSelector';
 import BirthDateInput from '@/components/BirthDateInput';
 import StudentDetailsInput from '@/components/StudentDetailsInput';
+import GoalWallpaperPreview from '@/components/GoalWallpaperPreview';
 import ViewModeToggle from '@/components/ViewModeToggle';
 import SetupInstructions from '@/components/SetupInstructions';
 import AuthButton from '@/components/AuthButton';
+import { deriveGoalEndDateFromDuration } from '@/lib/student-view';
 
 const STORAGE_KEY = 'remainders-user-profile';
 const THEME_COLOR = 'FFFFFF'; // White for minimalist dark theme
@@ -21,7 +23,7 @@ export default function Home() {
   const [birthDate, setBirthDate] = useState('');
   const [studyStartDate, setStudyStartDate] = useState('');
   const [universityName, setUniversityName] = useState('');
-  const [studyDurationYears, setStudyDurationYears] = useState('');
+  const [goalEndDate, setGoalEndDate] = useState('');
   const [selectedDevice, setSelectedDevice] = useState<DeviceModel | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>('life');
   const [isMondayFirst, setIsMondayFirst] = useState(false);
@@ -40,7 +42,11 @@ export default function Home() {
         setBirthDate(profile.birthDate);
         setStudyStartDate(profile.studyStartDate || '');
         setUniversityName(profile.universityName || '');
-        setStudyDurationYears(profile.studyDurationYears ? String(profile.studyDurationYears) : '');
+        setGoalEndDate(
+          profile.goalEndDate ||
+          deriveGoalEndDateFromDuration(profile.studyStartDate || '', profile.studyDurationYears) ||
+          ''
+        );
         if (profile.viewMode) setViewMode(profile.viewMode);
         if (profile.isMondayFirst !== undefined) setIsMondayFirst(profile.isMondayFirst);
         if ((profile as any).yearViewLayout) setYearViewLayout((profile as any).yearViewLayout);
@@ -66,15 +72,15 @@ export default function Home() {
     const canSaveProfile = selectedDevice !== null && (
       viewMode === 'year' ||
       (viewMode === 'life' && Boolean(birthDate)) ||
-      (viewMode === 'student' && Boolean(studyStartDate) && Boolean(universityName.trim()) && Boolean(studyDurationYears))
+      (viewMode === 'student' && Boolean(studyStartDate) && Boolean(universityName.trim()) && Boolean(goalEndDate))
     );
 
     if (canSaveProfile && selectedDevice) {
-        const profile: any = {
-          birthDate,
-          studyStartDate,
-          universityName: universityName.trim(),
-          studyDurationYears: studyDurationYears ? parseInt(studyDurationYears, 10) : undefined,
+      const profile: any = {
+        birthDate,
+        studyStartDate,
+        universityName: universityName.trim(),
+        goalEndDate,
         themeColor: THEME_COLOR,
         device: {
           brand: selectedDevice.brand,
@@ -94,12 +100,12 @@ export default function Home() {
         console.error('Failed to save profile:', error);
       }
     }
-  }, [birthDate, studyStartDate, universityName, studyDurationYears, selectedDevice, viewMode, isMondayFirst, yearViewLayout, daysLayoutMode]);
+  }, [birthDate, studyStartDate, universityName, goalEndDate, selectedDevice, viewMode, isMondayFirst, yearViewLayout, daysLayoutMode]);
 
-  const generateWallpaperUrl = () => {
+  const buildWallpaperPath = () => {
     if (!selectedDevice || !selectedDevice.width || !selectedDevice.height) return;
     if (viewMode === 'life' && !birthDate) return;
-    if (viewMode === 'student' && (!studyStartDate || !universityName.trim() || !studyDurationYears)) return;
+    if (viewMode === 'student' && (!studyStartDate || !universityName.trim() || !goalEndDate)) return;
 
     const params = new URLSearchParams({
       themeColor: THEME_COLOR,
@@ -115,7 +121,7 @@ export default function Home() {
     if (viewMode === 'student') {
       params.append('studyStartDate', studyStartDate);
       params.append('universityName', universityName.trim());
-      params.append('studyDurationYears', studyDurationYears);
+      params.append('goalEndDate', goalEndDate);
     }
     
     if (viewMode === 'year') {
@@ -128,11 +134,18 @@ export default function Home() {
       }
     }
 
+    return `/api/wallpaper?${params.toString()}`;
+  };
+
+  const generateWallpaperUrl = () => {
+    const path = buildWallpaperPath();
+    if (!path) return;
+
     const baseUrl = typeof window !== 'undefined'
       ? `${window.location.protocol}//${window.location.host}`
       : '';
 
-    const url = `${baseUrl}/api/wallpaper?${params.toString()}`;
+    const url = `${baseUrl}${path}`;
     setWallpaperUrl(url);
   };
 
@@ -141,7 +154,7 @@ export default function Home() {
     if (isFormComplete && !wallpaperUrl) {
       generateWallpaperUrl();
     }
-  }, [selectedDevice, birthDate, studyStartDate, universityName, studyDurationYears, viewMode, isMondayFirst, yearViewLayout, daysLayoutMode]);
+  }, [selectedDevice, birthDate, studyStartDate, universityName, goalEndDate, viewMode, isMondayFirst, yearViewLayout, daysLayoutMode]);
 
   const copyToClipboard = async () => {
     try {
@@ -157,7 +170,7 @@ export default function Home() {
     ? selectedDevice !== null
     : viewMode === 'life'
       ? Boolean(birthDate && selectedDevice)
-      : Boolean(studyStartDate && universityName.trim() && studyDurationYears && selectedDevice);
+      : Boolean(studyStartDate && universityName.trim() && goalEndDate && selectedDevice);
 
   return (
     <main className="min-h-screen flex flex-col items-center justify-between p-6 selection:bg-white selection:text-black relative">
@@ -290,11 +303,11 @@ export default function Home() {
               <StudentDetailsInput
                 studyStartDate={studyStartDate}
                 universityName={universityName}
-                studyDurationYears={studyDurationYears}
+                goalEndDate={goalEndDate}
                 selectedDeviceLabel={selectedDevice?.model || ''}
                 onStudyStartDateChange={setStudyStartDate}
                 onUniversityNameChange={setUniversityName}
-                onStudyDurationYearsChange={setStudyDurationYears}
+                onGoalEndDateChange={setGoalEndDate}
               />
             )}
 
@@ -336,20 +349,25 @@ export default function Home() {
               </button>
             </div>
 
-            <div className="text-center">
-              <a
-                href={wallpaperUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={viewMode === 'student'
-                  ? 'block w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-4 text-sm font-medium uppercase tracking-[0.22em] text-white transition-colors hover:bg-white/10'
-                  : 'text-xs text-neutral-500 hover:text-white transition-colors border-b border-transparent hover:border-white pb-0.5'
-                }
-                aria-label="Open wallpaper preview in new tab"
-              >
-                {viewMode === 'student' ? 'Install' : 'Preview Wallpaper'}
-              </a>
-            </div>
+            {viewMode === 'student' && (
+              <GoalWallpaperPreview
+                previewUrl={wallpaperUrl}
+              />
+            )}
+
+            {viewMode !== 'student' && (
+              <div className="text-center">
+                <a
+                  href={wallpaperUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-neutral-500 hover:text-white transition-colors border-b border-transparent hover:border-white pb-0.5"
+                  aria-label="Open wallpaper preview in new tab"
+                >
+                  Preview Wallpaper
+                </a>
+              </div>
+            )}
 
             <SetupInstructions wallpaperUrl={wallpaperUrl} selectedBrand={selectedDevice?.brand || ''} />
           </section>

--- a/components/GoalWallpaperPreview.tsx
+++ b/components/GoalWallpaperPreview.tsx
@@ -8,18 +8,18 @@ export default function GoalWallpaperPreview({
   previewUrl,
 }: GoalWallpaperPreviewProps) {
   return (
-    <div className="animate-in fade-in slide-in-from-bottom-4 duration-500">
+    <div className="animate-in fade-in slide-in-from-bottom-4 duration-500 text-center">
       {previewUrl ? (
         <a
           href={previewUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="block rounded-[14px] border border-white/5 bg-[#0d0d0f] px-4 py-2 text-center text-[13px] font-medium tracking-[0.01em] text-slate-400 transition-colors hover:text-white"
+          className="inline-block text-xs text-neutral-500 uppercase tracking-wider transition-colors hover:text-white"
         >
           Preview Wallpaper
         </a>
       ) : (
-        <div className="rounded-[14px] border border-white/5 bg-[#0d0d0f] px-4 py-2 text-center text-[13px] font-medium tracking-[0.01em] text-slate-400">
+        <div className="inline-block text-xs text-neutral-500 uppercase tracking-wider">
           Preview Wallpaper
         </div>
       )}

--- a/components/GoalWallpaperPreview.tsx
+++ b/components/GoalWallpaperPreview.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+interface GoalWallpaperPreviewProps {
+  previewUrl: string;
+}
+
+export default function GoalWallpaperPreview({
+  previewUrl,
+}: GoalWallpaperPreviewProps) {
+  return (
+    <div className="animate-in fade-in slide-in-from-bottom-4 duration-500">
+      {previewUrl ? (
+        <a
+          href={previewUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block rounded-[14px] border border-white/5 bg-[#0d0d0f] px-4 py-2 text-center text-[13px] font-medium tracking-[0.01em] text-slate-400 transition-colors hover:text-white"
+        >
+          Preview Wallpaper
+        </a>
+      ) : (
+        <div className="rounded-[14px] border border-white/5 bg-[#0d0d0f] px-4 py-2 text-center text-[13px] font-medium tracking-[0.01em] text-slate-400">
+          Preview Wallpaper
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/StudentDetailsInput.tsx
+++ b/components/StudentDetailsInput.tsx
@@ -92,7 +92,7 @@ export default function StudentDetailsInput({
             Define your Wallpaper
           </h3>
           <p className="text-sm text-neutral-500">
-            Build a student countdown that ends with graduation in July.
+            Build a goal countdown that ends with your graduation deadline.
           </p>
         </div>
       </div>
@@ -198,7 +198,7 @@ export default function StudentDetailsInput({
       <div className="rounded-[30px] border border-white/8 bg-[#0b0b0d] px-4 py-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
         <div className="text-center">
           <h4 className="text-[28px] font-semibold tracking-tight text-white">
-            Student Calendar
+            Goal Calendar
           </h4>
           <p className="mt-2 text-sm text-neutral-500">
             Count down to your graduation deadline

--- a/components/StudentDetailsInput.tsx
+++ b/components/StudentDetailsInput.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+interface StudentDetailsInputProps {
+  studyStartDate: string;
+  universityName: string;
+  studyDurationYears: string;
+  onStudyStartDateChange: (date: string) => void;
+  onUniversityNameChange: (name: string) => void;
+  onStudyDurationYearsChange: (years: string) => void;
+}
+
+export default function StudentDetailsInput({
+  studyStartDate,
+  universityName,
+  studyDurationYears,
+  onStudyStartDateChange,
+  onUniversityNameChange,
+  onStudyDurationYearsChange,
+}: StudentDetailsInputProps) {
+  const today = new Date();
+  const minDate = new Date();
+  minDate.setFullYear(today.getFullYear() - 50);
+
+  const maxDate = new Date();
+  maxDate.setFullYear(today.getFullYear() + 10);
+
+  return (
+    <div className="space-y-6">
+      <div className="w-full group">
+        <label
+          htmlFor="studyStartDate"
+          className="text-xs uppercase tracking-widest text-neutral-500 mb-1 block group-focus-within:text-white transition-colors"
+        >
+          Study Start Date
+        </label>
+        <input
+          id="studyStartDate"
+          type="date"
+          value={studyStartDate}
+          onChange={(e) => onStudyStartDateChange(e.target.value)}
+          min={minDate.toISOString().split('T')[0]}
+          max={maxDate.toISOString().split('T')[0]}
+          className="input-minimal text-white placeholder:text-neutral-700 bg-black/30 border border-white/20 [color-scheme:dark]"
+          style={{ colorScheme: 'dark' }}
+        />
+      </div>
+
+      <div className="w-full group">
+        <label
+          htmlFor="universityName"
+          className="text-xs uppercase tracking-widest text-neutral-500 mb-1 block group-focus-within:text-white transition-colors"
+        >
+          University
+        </label>
+        <input
+          id="universityName"
+          type="text"
+          value={universityName}
+          onChange={(e) => onUniversityNameChange(e.target.value)}
+          placeholder="University of Jordan"
+          maxLength={60}
+          className="input-minimal text-white placeholder:text-neutral-700"
+        />
+      </div>
+
+      <div className="w-full group">
+        <label
+          htmlFor="studyDurationYears"
+          className="text-xs uppercase tracking-widest text-neutral-500 mb-1 block group-focus-within:text-white transition-colors"
+        >
+          Study Duration (Years)
+        </label>
+        <input
+          id="studyDurationYears"
+          type="number"
+          inputMode="numeric"
+          min="1"
+          max="10"
+          step="1"
+          value={studyDurationYears}
+          onChange={(e) => onStudyDurationYearsChange(e.target.value)}
+          placeholder="4"
+          className="input-minimal text-white placeholder:text-neutral-700"
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/StudentDetailsInput.tsx
+++ b/components/StudentDetailsInput.tsx
@@ -1,87 +1,260 @@
 'use client';
 
+import { useState } from 'react';
+import { getAcademicGraduationDate } from '@/lib/student-view';
+
 interface StudentDetailsInputProps {
   studyStartDate: string;
   universityName: string;
   studyDurationYears: string;
+  selectedDeviceLabel?: string;
   onStudyStartDateChange: (date: string) => void;
   onUniversityNameChange: (name: string) => void;
   onStudyDurationYearsChange: (years: string) => void;
+}
+
+const PREVIEW_DOTS = 48;
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function parseDate(value: string): Date | null {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const date = new Date(`${value}T00:00:00`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function formatDateParts(date: Date | null): [string, string, string] {
+  if (!date) return ['Year', 'Month', 'Day'];
+  return [
+    String(date.getFullYear()),
+    MONTHS[date.getMonth()],
+    String(date.getDate()).padStart(2, '0'),
+  ];
+}
+
+function formatCompactDate(date: Date | null): string {
+  if (!date) return 'Not set';
+  return `${MONTHS[date.getMonth()]} ${date.getDate()}, ${date.getFullYear()}`;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
 }
 
 export default function StudentDetailsInput({
   studyStartDate,
   universityName,
   studyDurationYears,
+  selectedDeviceLabel,
   onStudyStartDateChange,
   onUniversityNameChange,
   onStudyDurationYearsChange,
 }: StudentDetailsInputProps) {
-  const today = new Date();
-  const minDate = new Date();
+  const [today] = useState(() => new Date());
+
+  const minDate = new Date(today);
   minDate.setFullYear(today.getFullYear() - 50);
 
-  const maxDate = new Date();
+  const maxDate = new Date(today);
   maxDate.setFullYear(today.getFullYear() + 10);
 
+  const startDate = parseDate(studyStartDate);
+  const durationYears = clamp(parseInt(studyDurationYears || '0', 10) || 0, 0, 10);
+  const graduationDate = startDate && durationYears > 0
+    ? getAcademicGraduationDate(startDate, durationYears)
+    : null;
+
+  const totalDays = startDate && graduationDate
+    ? Math.max(1, Math.ceil((graduationDate.getTime() - startDate.getTime()) / DAY_MS))
+    : null;
+  const elapsedDays = startDate && totalDays
+    ? clamp(Math.floor((today.getTime() - startDate.getTime()) / DAY_MS), 0, totalDays)
+    : null;
+  const progressRatio = totalDays && elapsedDays !== null ? elapsedDays / totalDays : 0;
+  const completedDots = Math.round(progressRatio * PREVIEW_DOTS);
+  const remainingDays = totalDays && elapsedDays !== null ? Math.max(totalDays - elapsedDays, 0) : null;
+
+  const [startYear, startMonth, startDay] = formatDateParts(startDate);
+  const [gradYear, gradMonth, gradDay] = formatDateParts(graduationDate);
+  const title = universityName.trim() || 'Your University';
+  const previewDeviceLabel = selectedDeviceLabel || 'Select device below';
+
   return (
-    <div className="space-y-6">
-      <div className="w-full group">
-        <label
-          htmlFor="studyStartDate"
-          className="text-xs uppercase tracking-widest text-neutral-500 mb-1 block group-focus-within:text-white transition-colors"
-        >
-          Study Start Date
-        </label>
-        <input
-          id="studyStartDate"
-          type="date"
-          value={studyStartDate}
-          onChange={(e) => onStudyStartDateChange(e.target.value)}
-          min={minDate.toISOString().split('T')[0]}
-          max={maxDate.toISOString().split('T')[0]}
-          className="input-minimal text-white placeholder:text-neutral-700 bg-black/30 border border-white/20 [color-scheme:dark]"
-          style={{ colorScheme: 'dark' }}
-        />
+    <div className="space-y-6 rounded-[28px] border border-white/10 bg-[linear-gradient(180deg,rgba(18,18,20,0.98)_0%,rgba(8,8,10,0.98)_100%)] p-5 shadow-[0_30px_80px_rgba(0,0,0,0.45)] sm:p-6">
+      <div className="mx-auto h-1.5 w-20 rounded-full bg-white/10" />
+
+      <div className="flex items-start gap-4">
+        <div className="flex h-10 w-10 items-center justify-center rounded-md bg-white text-base font-semibold text-black shadow-sm">
+          1
+        </div>
+        <div className="space-y-1">
+          <h3 className="text-2xl font-semibold tracking-tight text-white">
+            Define your Wallpaper
+          </h3>
+          <p className="text-sm text-neutral-500">
+            Build a student countdown that ends with graduation in July.
+          </p>
+        </div>
       </div>
 
-      <div className="w-full group">
-        <label
-          htmlFor="universityName"
-          className="text-xs uppercase tracking-widest text-neutral-500 mb-1 block group-focus-within:text-white transition-colors"
-        >
-          University
-        </label>
-        <input
-          id="universityName"
-          type="text"
-          value={universityName}
-          onChange={(e) => onUniversityNameChange(e.target.value)}
-          placeholder="University of Jordan"
-          maxLength={60}
-          className="input-minimal text-white placeholder:text-neutral-700"
-        />
+      <div className="space-y-5">
+        <div className="space-y-2">
+          <label htmlFor="universityName" className="text-sm font-medium text-neutral-400">
+            University
+          </label>
+          <input
+            id="universityName"
+            type="text"
+            value={universityName}
+            onChange={(e) => onUniversityNameChange(e.target.value)}
+            placeholder="e.g. Jordan University of Science and Technology"
+            maxLength={60}
+            className="w-full rounded-2xl border border-white/10 bg-[#111215] px-4 py-3 text-base text-white outline-none transition-colors placeholder:text-neutral-600 focus:border-white/30 focus:bg-[#15161a]"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="studyStartDate" className="text-sm font-medium text-neutral-400">
+            Start Date
+          </label>
+          <input
+            id="studyStartDate"
+            type="date"
+            value={studyStartDate}
+            onChange={(e) => onStudyStartDateChange(e.target.value)}
+            min={minDate.toISOString().split('T')[0]}
+            max={maxDate.toISOString().split('T')[0]}
+            className="w-full rounded-2xl border border-white/10 bg-[#111215] px-4 py-3 text-base text-white outline-none transition-colors [color-scheme:dark] focus:border-white/30 focus:bg-[#15161a]"
+            style={{ colorScheme: 'dark' }}
+          />
+          <div className="grid grid-cols-3 gap-2">
+            {[startYear, startMonth, startDay].map((part, index) => (
+              <div
+                key={`${part}-${index}`}
+                className="rounded-2xl border border-white/10 bg-[#101114] px-3 py-3 text-center text-sm text-neutral-300"
+              >
+                {part}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-[minmax(0,160px)_1fr]">
+          <div className="space-y-2">
+            <label htmlFor="studyDurationYears" className="text-sm font-medium text-neutral-400">
+              Years
+            </label>
+            <input
+              id="studyDurationYears"
+              type="number"
+              inputMode="numeric"
+              min="1"
+              max="10"
+              step="1"
+              value={studyDurationYears}
+              onChange={(e) => onStudyDurationYearsChange(e.target.value)}
+              placeholder="5"
+              className="w-full rounded-2xl border border-white/10 bg-[#111215] px-4 py-3 text-base text-white outline-none transition-colors placeholder:text-neutral-600 focus:border-white/30 focus:bg-[#15161a]"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-neutral-400">
+              Graduation
+            </label>
+            <div className="rounded-2xl border border-white/10 bg-[#101114] p-3">
+              <div className="grid grid-cols-3 gap-2">
+                {[gradYear, gradMonth, gradDay].map((part, index) => (
+                  <div
+                    key={`${part}-${index}`}
+                    className="rounded-2xl border border-white/10 bg-[#141519] px-3 py-3 text-center text-sm text-neutral-300"
+                  >
+                    {part}
+                  </div>
+                ))}
+              </div>
+              <p className="mt-3 text-xs uppercase tracking-[0.25em] text-neutral-500">
+                Calculated from your July graduation timeline
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-white/10 bg-[#101114] p-4">
+          <div className="text-xs uppercase tracking-[0.24em] text-neutral-500">
+            Preview Setup
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-neutral-400">
+            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1">
+              {previewDeviceLabel}
+            </span>
+            <span className="rounded-full border border-[#FF6B35]/30 bg-[#FF6B35]/10 px-3 py-1 text-[#FF6B35]">
+              {durationYears > 0 ? `${durationYears} year${durationYears === 1 ? '' : 's'}` : 'Set duration'}
+            </span>
+          </div>
+        </div>
       </div>
 
-      <div className="w-full group">
-        <label
-          htmlFor="studyDurationYears"
-          className="text-xs uppercase tracking-widest text-neutral-500 mb-1 block group-focus-within:text-white transition-colors"
-        >
-          Study Duration (Years)
-        </label>
-        <input
-          id="studyDurationYears"
-          type="number"
-          inputMode="numeric"
-          min="1"
-          max="10"
-          step="1"
-          value={studyDurationYears}
-          onChange={(e) => onStudyDurationYearsChange(e.target.value)}
-          placeholder="4"
-          className="input-minimal text-white placeholder:text-neutral-700"
-        />
+      <div className="rounded-[30px] border border-white/8 bg-[#0b0b0d] px-4 py-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
+        <div className="text-center">
+          <h4 className="text-[28px] font-semibold tracking-tight text-white">
+            Student Calendar
+          </h4>
+          <p className="mt-2 text-sm text-neutral-500">
+            Count down to your graduation deadline
+          </p>
+        </div>
+
+        <div className="mt-6 flex justify-center">
+          <div className="relative h-[420px] w-[210px] rounded-[38px] border border-white/10 bg-[radial-gradient(circle_at_top,#202124_0%,#131416_48%,#0b0b0d_100%)] p-4 shadow-[0_20px_70px_rgba(0,0,0,0.55)]">
+            <div className="mx-auto h-5 w-24 rounded-full bg-black/70" />
+
+            <div className="mt-8 flex h-full flex-col items-center text-center">
+              <div className="text-[10px] uppercase tracking-[0.28em] text-neutral-600">
+                {graduationDate ? formatCompactDate(graduationDate) : 'Graduation Deadline'}
+              </div>
+              <div className="mt-10 text-sm text-neutral-500">
+                {title}
+              </div>
+
+              <div className="mt-5 grid grid-cols-8 gap-1.5">
+                {Array.from({ length: PREVIEW_DOTS }).map((_, index) => {
+                  const isCurrent = completedDots > 0 && index === completedDots - 1 && progressRatio < 1;
+                  const isCompleted = index < completedDots;
+
+                  return (
+                    <span
+                      key={index}
+                      className={`h-2.5 w-2.5 rounded-full ${
+                        isCurrent
+                          ? 'bg-[#FF6B35]'
+                          : isCompleted
+                            ? 'bg-white'
+                            : 'bg-neutral-700'
+                      }`}
+                    />
+                  );
+                })}
+              </div>
+
+              <div className="mt-5 text-[11px] uppercase tracking-[0.24em] text-neutral-600">
+                {startDate ? formatCompactDate(startDate) : 'Choose a start date'}
+              </div>
+
+              <div className="mt-2 text-[11px] text-neutral-500">
+                {remainingDays !== null && graduationDate
+                  ? `${remainingDays} days left until ${formatCompactDate(graduationDate)}`
+                  : 'Set your timeline to preview progress'}
+              </div>
+
+              <div className="mt-auto w-full pb-3">
+                <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-medium text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
+                  Install
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/components/StudentDetailsInput.tsx
+++ b/components/StudentDetailsInput.tsx
@@ -1,35 +1,22 @@
 'use client';
 
-import { useState } from 'react';
-import { getAcademicGraduationDate } from '@/lib/student-view';
-
 interface StudentDetailsInputProps {
   studyStartDate: string;
   universityName: string;
-  studyDurationYears: string;
+  goalEndDate: string;
   selectedDeviceLabel?: string;
   onStudyStartDateChange: (date: string) => void;
   onUniversityNameChange: (name: string) => void;
-  onStudyDurationYearsChange: (years: string) => void;
+  onGoalEndDateChange: (date: string) => void;
 }
-
-const PREVIEW_DOTS = 48;
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 function parseDate(value: string): Date | null {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+
   const date = new Date(`${value}T00:00:00`);
   return Number.isNaN(date.getTime()) ? null : date;
-}
-
-function formatDateParts(date: Date | null): [string, string, string] {
-  if (!date) return ['Year', 'Month', 'Day'];
-  return [
-    String(date.getFullYear()),
-    MONTHS[date.getMonth()],
-    String(date.getDate()).padStart(2, '0'),
-  ];
 }
 
 function formatCompactDate(date: Date | null): string {
@@ -44,217 +31,140 @@ function clamp(value: number, min: number, max: number): number {
 export default function StudentDetailsInput({
   studyStartDate,
   universityName,
-  studyDurationYears,
+  goalEndDate,
   selectedDeviceLabel,
   onStudyStartDateChange,
   onUniversityNameChange,
-  onStudyDurationYearsChange,
+  onGoalEndDateChange,
 }: StudentDetailsInputProps) {
-  const [today] = useState(() => new Date());
+  const today = new Date();
 
   const minDate = new Date(today);
   minDate.setFullYear(today.getFullYear() - 50);
 
   const maxDate = new Date(today);
-  maxDate.setFullYear(today.getFullYear() + 10);
+  maxDate.setFullYear(today.getFullYear() + 15);
 
   const startDate = parseDate(studyStartDate);
-  const durationYears = clamp(parseInt(studyDurationYears || '0', 10) || 0, 0, 10);
-  const graduationDate = startDate && durationYears > 0
-    ? getAcademicGraduationDate(startDate, durationYears)
-    : null;
+  const endDate = parseDate(goalEndDate);
+  const hasValidTimeline = Boolean(startDate && endDate && endDate.getTime() > startDate.getTime());
 
-  const totalDays = startDate && graduationDate
-    ? Math.max(1, Math.ceil((graduationDate.getTime() - startDate.getTime()) / DAY_MS))
+  const totalDays = hasValidTimeline && startDate && endDate
+    ? Math.max(1, Math.ceil((endDate.getTime() - startDate.getTime()) / DAY_MS))
     : null;
   const elapsedDays = startDate && totalDays
     ? clamp(Math.floor((today.getTime() - startDate.getTime()) / DAY_MS), 0, totalDays)
     : null;
-  const progressRatio = totalDays && elapsedDays !== null ? elapsedDays / totalDays : 0;
-  const completedDots = Math.round(progressRatio * PREVIEW_DOTS);
   const remainingDays = totalDays && elapsedDays !== null ? Math.max(totalDays - elapsedDays, 0) : null;
-
-  const [startYear, startMonth, startDay] = formatDateParts(startDate);
-  const [gradYear, gradMonth, gradDay] = formatDateParts(graduationDate);
-  const title = universityName.trim() || 'Your University';
-  const previewDeviceLabel = selectedDeviceLabel || 'Select device below';
+  const progressLabel = totalDays && elapsedDays !== null
+    ? `${Math.round((elapsedDays / totalDays) * 100)}%`
+    : '0%';
 
   return (
-    <div className="space-y-6 rounded-[28px] border border-white/10 bg-[linear-gradient(180deg,rgba(18,18,20,0.98)_0%,rgba(8,8,10,0.98)_100%)] p-5 shadow-[0_30px_80px_rgba(0,0,0,0.45)] sm:p-6">
-      <div className="mx-auto h-1.5 w-20 rounded-full bg-white/10" />
-
-      <div className="flex items-start gap-4">
-        <div className="flex h-10 w-10 items-center justify-center rounded-md bg-white text-base font-semibold text-black shadow-sm">
-          1
-        </div>
-        <div className="space-y-1">
-          <h3 className="text-2xl font-semibold tracking-tight text-white">
-            Define your Wallpaper
-          </h3>
-          <p className="text-sm text-neutral-500">
-            Build a goal countdown that ends with your graduation deadline.
-          </p>
-        </div>
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h3 className="text-sm uppercase tracking-widest text-neutral-500">Goal View</h3>
+        <p className="text-sm text-neutral-500 leading-6">
+          Add a title, your start date, and the date you want the goal to end.
+        </p>
       </div>
 
       <div className="space-y-5">
-        <div className="space-y-2">
-          <label htmlFor="universityName" className="text-sm font-medium text-neutral-400">
-            University
+        <div className="w-full group">
+          <label
+            htmlFor="universityName"
+            className="mb-1 block text-xs uppercase tracking-widest text-neutral-500 transition-colors group-focus-within:text-white"
+          >
+            Goal Title
           </label>
           <input
             id="universityName"
             type="text"
             value={universityName}
             onChange={(e) => onUniversityNameChange(e.target.value)}
-            placeholder="e.g. Jordan University of Science and Technology"
+            placeholder="e.g. JUST Computer Engineering"
             maxLength={60}
-            className="w-full rounded-2xl border border-white/10 bg-[#111215] px-4 py-3 text-base text-white outline-none transition-colors placeholder:text-neutral-600 focus:border-white/30 focus:bg-[#15161a]"
+            className="input-minimal bg-black/30 text-white placeholder:text-neutral-700"
           />
         </div>
 
-        <div className="space-y-2">
-          <label htmlFor="studyStartDate" className="text-sm font-medium text-neutral-400">
-            Start Date
-          </label>
-          <input
-            id="studyStartDate"
-            type="date"
-            value={studyStartDate}
-            onChange={(e) => onStudyStartDateChange(e.target.value)}
-            min={minDate.toISOString().split('T')[0]}
-            max={maxDate.toISOString().split('T')[0]}
-            className="w-full rounded-2xl border border-white/10 bg-[#111215] px-4 py-3 text-base text-white outline-none transition-colors [color-scheme:dark] focus:border-white/30 focus:bg-[#15161a]"
-            style={{ colorScheme: 'dark' }}
-          />
-          <div className="grid grid-cols-3 gap-2">
-            {[startYear, startMonth, startDay].map((part, index) => (
-              <div
-                key={`${part}-${index}`}
-                className="rounded-2xl border border-white/10 bg-[#101114] px-3 py-3 text-center text-sm text-neutral-300"
-              >
-                {part}
-              </div>
-            ))}
-          </div>
-        </div>
-
-        <div className="grid gap-4 sm:grid-cols-[minmax(0,160px)_1fr]">
-          <div className="space-y-2">
-            <label htmlFor="studyDurationYears" className="text-sm font-medium text-neutral-400">
-              Years
+        <div className="grid gap-5 sm:grid-cols-2">
+          <div className="w-full group">
+            <label
+              htmlFor="studyStartDate"
+              className="mb-1 block text-xs uppercase tracking-widest text-neutral-500 transition-colors group-focus-within:text-white"
+            >
+              Start Date
             </label>
             <input
-              id="studyDurationYears"
-              type="number"
-              inputMode="numeric"
-              min="1"
-              max="10"
-              step="1"
-              value={studyDurationYears}
-              onChange={(e) => onStudyDurationYearsChange(e.target.value)}
-              placeholder="5"
-              className="w-full rounded-2xl border border-white/10 bg-[#111215] px-4 py-3 text-base text-white outline-none transition-colors placeholder:text-neutral-600 focus:border-white/30 focus:bg-[#15161a]"
+              id="studyStartDate"
+              type="date"
+              value={studyStartDate}
+              onChange={(e) => onStudyStartDateChange(e.target.value)}
+              min={minDate.toISOString().split('T')[0]}
+              max={maxDate.toISOString().split('T')[0]}
+              className="input-minimal bg-black/30 text-white [color-scheme:dark]"
+              style={{ colorScheme: 'dark' }}
             />
           </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-neutral-400">
-              Graduation
+          <div className="w-full group">
+            <label
+              htmlFor="goalEndDate"
+              className="mb-1 block text-xs uppercase tracking-widest text-neutral-500 transition-colors group-focus-within:text-white"
+            >
+              End Date
             </label>
-            <div className="rounded-2xl border border-white/10 bg-[#101114] p-3">
-              <div className="grid grid-cols-3 gap-2">
-                {[gradYear, gradMonth, gradDay].map((part, index) => (
-                  <div
-                    key={`${part}-${index}`}
-                    className="rounded-2xl border border-white/10 bg-[#141519] px-3 py-3 text-center text-sm text-neutral-300"
-                  >
-                    {part}
-                  </div>
-                ))}
-              </div>
-              <p className="mt-3 text-xs uppercase tracking-[0.25em] text-neutral-500">
-                Calculated from your July graduation timeline
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div className="rounded-2xl border border-white/10 bg-[#101114] p-4">
-          <div className="text-xs uppercase tracking-[0.24em] text-neutral-500">
-            Preview Setup
-          </div>
-          <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-neutral-400">
-            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1">
-              {previewDeviceLabel}
-            </span>
-            <span className="rounded-full border border-[#FF6B35]/30 bg-[#FF6B35]/10 px-3 py-1 text-[#FF6B35]">
-              {durationYears > 0 ? `${durationYears} year${durationYears === 1 ? '' : 's'}` : 'Set duration'}
-            </span>
+            <input
+              id="goalEndDate"
+              type="date"
+              value={goalEndDate}
+              onChange={(e) => onGoalEndDateChange(e.target.value)}
+              min={studyStartDate || minDate.toISOString().split('T')[0]}
+              max={maxDate.toISOString().split('T')[0]}
+              className="input-minimal bg-black/30 text-white [color-scheme:dark]"
+              style={{ colorScheme: 'dark' }}
+            />
           </div>
         </div>
       </div>
 
-      <div className="rounded-[30px] border border-white/8 bg-[#0b0b0d] px-4 py-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]">
-        <div className="text-center">
-          <h4 className="text-[28px] font-semibold tracking-tight text-white">
-            Goal Calendar
-          </h4>
-          <p className="mt-2 text-sm text-neutral-500">
-            Count down to your graduation deadline
-          </p>
-        </div>
+      <div className="rounded-lg border border-white/10 bg-white/[0.03] p-4 space-y-3">
+        <div className="text-xs uppercase tracking-widest text-neutral-500">Timeline Summary</div>
 
-        <div className="mt-6 flex justify-center">
-          <div className="relative h-[420px] w-[210px] rounded-[38px] border border-white/10 bg-[radial-gradient(circle_at_top,#202124_0%,#131416_48%,#0b0b0d_100%)] p-4 shadow-[0_20px_70px_rgba(0,0,0,0.55)]">
-            <div className="mx-auto h-5 w-24 rounded-full bg-black/70" />
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div>
+            <div className="text-[11px] uppercase tracking-widest text-neutral-600">Start</div>
+            <div className="mt-1 text-sm text-white">{formatCompactDate(startDate)}</div>
+          </div>
 
-            <div className="mt-8 flex h-full flex-col items-center text-center">
-              <div className="text-[10px] uppercase tracking-[0.28em] text-neutral-600">
-                {graduationDate ? formatCompactDate(graduationDate) : 'Graduation Deadline'}
-              </div>
-              <div className="mt-10 text-sm text-neutral-500">
-                {title}
-              </div>
+          <div>
+            <div className="text-[11px] uppercase tracking-widest text-neutral-600">End</div>
+            <div className="mt-1 text-sm text-white">
+              {endDate ? formatCompactDate(endDate) : 'Choose an end date'}
+            </div>
+          </div>
 
-              <div className="mt-5 grid grid-cols-8 gap-1.5">
-                {Array.from({ length: PREVIEW_DOTS }).map((_, index) => {
-                  const isCurrent = completedDots > 0 && index === completedDots - 1 && progressRatio < 1;
-                  const isCompleted = index < completedDots;
+          <div>
+            <div className="text-[11px] uppercase tracking-widest text-neutral-600">Progress</div>
+            <div className="mt-1 text-sm text-white">
+              {remainingDays !== null ? `${progressLabel} complete` : 'Waiting for a valid timeline'}
+            </div>
+          </div>
 
-                  return (
-                    <span
-                      key={index}
-                      className={`h-2.5 w-2.5 rounded-full ${
-                        isCurrent
-                          ? 'bg-[#FF6B35]'
-                          : isCompleted
-                            ? 'bg-white'
-                            : 'bg-neutral-700'
-                      }`}
-                    />
-                  );
-                })}
-              </div>
-
-              <div className="mt-5 text-[11px] uppercase tracking-[0.24em] text-neutral-600">
-                {startDate ? formatCompactDate(startDate) : 'Choose a start date'}
-              </div>
-
-              <div className="mt-2 text-[11px] text-neutral-500">
-                {remainingDays !== null && graduationDate
-                  ? `${remainingDays} days left until ${formatCompactDate(graduationDate)}`
-                  : 'Set your timeline to preview progress'}
-              </div>
-
-              <div className="mt-auto w-full pb-3">
-                <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-medium text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
-                  Install
-                </div>
-              </div>
+          <div>
+            <div className="text-[11px] uppercase tracking-widest text-neutral-600">Remaining</div>
+            <div className="mt-1 text-sm text-white">
+              {remainingDays !== null ? `${remainingDays} days left` : 'Waiting for a valid timeline'}
             </div>
           </div>
         </div>
+
+        {selectedDeviceLabel && (
+          <div className="border-t border-white/10 pt-3 text-xs uppercase tracking-widest text-neutral-600">
+            Device: <span className="text-neutral-300">{selectedDeviceLabel}</span>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/components/ViewModeToggle.tsx
+++ b/components/ViewModeToggle.tsx
@@ -14,7 +14,7 @@ interface ViewModeToggleProps {
 
 export default function ViewModeToggle({ selectedMode, onChange }: ViewModeToggleProps) {
   return (
-    <div className="w-full flex p-1 bg-white/5 rounded-lg border border-white/5">
+    <div className="w-full flex p-1 bg-white/5 rounded-lg border border-white/5 gap-1">
       <button
         onClick={() => onChange('life')}
         className={`
@@ -26,6 +26,18 @@ export default function ViewModeToggle({ selectedMode, onChange }: ViewModeToggl
         `}
       >
         Life View
+      </button>
+      <button
+        onClick={() => onChange('student')}
+        className={`
+          flex-1 py-2 text-xs uppercase tracking-widest font-medium rounded transition-all
+          ${selectedMode === 'student'
+            ? 'bg-white text-black shadow-sm'
+            : 'text-neutral-500 hover:text-neutral-300'
+          }
+        `}
+      >
+        Student View
       </button>
       <button
         onClick={() => onChange('year')}

--- a/components/ViewModeToggle.tsx
+++ b/components/ViewModeToggle.tsx
@@ -37,7 +37,7 @@ export default function ViewModeToggle({ selectedMode, onChange }: ViewModeToggl
           }
         `}
       >
-        Student View
+        Goal View
       </button>
       <button
         onClick={() => onChange('year')}

--- a/lib/plugin-system.ts
+++ b/lib/plugin-system.ts
@@ -8,7 +8,7 @@
  * dangerous code before paying the isolate creation cost.
  */
 
-import { PluginContext, PluginCalculationResult, PluginRenderResult, Plugin, PluginConfig } from './types';
+import { PluginContext, PluginCalculationResult, PluginRenderResult, Plugin, PluginConfig, ViewMode } from './types';
 import { calculateWeeksLived, getCurrentDayOfYear } from './calcs';
 import * as acorn from 'acorn';
 import ivm from 'isolated-vm';
@@ -30,7 +30,7 @@ export function createPluginContext(
   birthDate: string,
   width: number,
   height: number,
-  viewMode: 'year' | 'life',
+  viewMode: ViewMode,
   settings: Record<string, any>,
   timezone?: string
 ): PluginContext {

--- a/lib/student-view.ts
+++ b/lib/student-view.ts
@@ -1,0 +1,92 @@
+export interface NormalizedStudentViewInput {
+  studyStartDate: string;
+  universityName: string;
+  studyDurationYears: number;
+}
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const MIN_START_YEAR = 1950;
+const MAX_START_YEAR = 2100;
+const MIN_DURATION_YEARS = 1;
+const MAX_DURATION_YEARS = 10;
+const MAX_UNIVERSITY_NAME_LENGTH = 80;
+
+function parseIsoDate(value: string): Date | null {
+  if (!ISO_DATE_PATTERN.test(value)) return null;
+
+  const [yearStr, monthStr, dayStr] = value.split('-');
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) {
+    return null;
+  }
+
+  if (year < MIN_START_YEAR || year > MAX_START_YEAR) {
+    return null;
+  }
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return date;
+}
+
+function sanitizeUniversityName(value: string): string {
+  return value
+    .replace(/[\u0000-\u001F\u007F]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function normalizeStudentViewInput(input: {
+  studyStartDate: string;
+  universityName: string;
+  studyDurationYears: number | string;
+}): { ok: true; value: NormalizedStudentViewInput } | { ok: false; error: string } {
+  const studyStartDate = String(input.studyStartDate || '').trim();
+  const universityName = sanitizeUniversityName(String(input.universityName || ''));
+  const duration = typeof input.studyDurationYears === 'number'
+    ? input.studyDurationYears
+    : Number.parseInt(String(input.studyDurationYears || '').trim(), 10);
+
+  if (!parseIsoDate(studyStartDate)) {
+    return { ok: false, error: 'Invalid studyStartDate. Use YYYY-MM-DD.' };
+  }
+
+  if (!universityName) {
+    return { ok: false, error: 'University name is required.' };
+  }
+
+  if (universityName.length > MAX_UNIVERSITY_NAME_LENGTH) {
+    return { ok: false, error: `University name must be ${MAX_UNIVERSITY_NAME_LENGTH} characters or fewer.` };
+  }
+
+  if (!Number.isInteger(duration) || duration < MIN_DURATION_YEARS || duration > MAX_DURATION_YEARS) {
+    return { ok: false, error: `studyDurationYears must be an integer between ${MIN_DURATION_YEARS} and ${MAX_DURATION_YEARS}.` };
+  }
+
+  return {
+    ok: true,
+    value: {
+      studyStartDate,
+      universityName,
+      studyDurationYears: duration,
+    },
+  };
+}
+
+export function getAcademicGraduationDate(startDate: Date, durationYears: number): Date {
+  return new Date(startDate.getFullYear() + durationYears, 6, 31, 23, 59, 59, 999);
+}
+
+export function isSafeWallpaperDimension(value: number, min: number, max: number): boolean {
+  return Number.isInteger(value) && value >= min && value <= max;
+}

--- a/lib/student-view.ts
+++ b/lib/student-view.ts
@@ -1,15 +1,16 @@
 export interface NormalizedStudentViewInput {
   studyStartDate: string;
   universityName: string;
+  goalEndDate: string;
   studyDurationYears: number;
 }
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const MIN_START_YEAR = 1950;
-const MAX_START_YEAR = 2100;
-const MIN_DURATION_YEARS = 1;
+const MAX_GOAL_YEAR = 2110;
 const MAX_DURATION_YEARS = 10;
 const MAX_UNIVERSITY_NAME_LENGTH = 80;
+const YEAR_MS = 365.25 * 24 * 60 * 60 * 1000;
 
 function parseIsoDate(value: string): Date | null {
   if (!ISO_DATE_PATTERN.test(value)) return null;
@@ -23,7 +24,7 @@ function parseIsoDate(value: string): Date | null {
     return null;
   }
 
-  if (year < MIN_START_YEAR || year > MAX_START_YEAR) {
+  if (year < MIN_START_YEAR || year > MAX_GOAL_YEAR) {
     return null;
   }
 
@@ -39,6 +40,13 @@ function parseIsoDate(value: string): Date | null {
   return date;
 }
 
+export function formatIsoDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 function sanitizeUniversityName(value: string): string {
   return value
     .replace(/[\u0000-\u001F\u007F]/g, '')
@@ -49,15 +57,19 @@ function sanitizeUniversityName(value: string): string {
 export function normalizeStudentViewInput(input: {
   studyStartDate: string;
   universityName: string;
-  studyDurationYears: number | string;
+  goalEndDate?: string;
+  studyDurationYears?: number | string;
 }): { ok: true; value: NormalizedStudentViewInput } | { ok: false; error: string } {
   const studyStartDate = String(input.studyStartDate || '').trim();
   const universityName = sanitizeUniversityName(String(input.universityName || ''));
+  const goalEndDate = String(input.goalEndDate || '').trim();
   const duration = typeof input.studyDurationYears === 'number'
     ? input.studyDurationYears
     : Number.parseInt(String(input.studyDurationYears || '').trim(), 10);
 
-  if (!parseIsoDate(studyStartDate)) {
+  const parsedStartDate = parseIsoDate(studyStartDate);
+
+  if (!parsedStartDate) {
     return { ok: false, error: 'Invalid studyStartDate. Use YYYY-MM-DD.' };
   }
 
@@ -69,8 +81,27 @@ export function normalizeStudentViewInput(input: {
     return { ok: false, error: `University name must be ${MAX_UNIVERSITY_NAME_LENGTH} characters or fewer.` };
   }
 
-  if (!Number.isInteger(duration) || duration < MIN_DURATION_YEARS || duration > MAX_DURATION_YEARS) {
-    return { ok: false, error: `studyDurationYears must be an integer between ${MIN_DURATION_YEARS} and ${MAX_DURATION_YEARS}.` };
+  let parsedGoalEndDate = goalEndDate ? parseIsoDate(goalEndDate) : null;
+
+  if (goalEndDate && !parsedGoalEndDate) {
+    return { ok: false, error: 'Invalid goalEndDate. Use YYYY-MM-DD.' };
+  }
+
+  if (!parsedGoalEndDate) {
+    if (!Number.isInteger(duration) || duration < 1 || duration > MAX_DURATION_YEARS) {
+      return { ok: false, error: `Provide a valid goalEndDate or a studyDurationYears value between 1 and ${MAX_DURATION_YEARS}.` };
+    }
+
+    parsedGoalEndDate = getAcademicGraduationDate(parsedStartDate, duration);
+  }
+
+  if (parsedGoalEndDate.getTime() <= parsedStartDate.getTime()) {
+    return { ok: false, error: 'goalEndDate must be after studyStartDate.' };
+  }
+
+  const spanYears = getGoalSpanYears(parsedStartDate, parsedGoalEndDate);
+  if (spanYears > MAX_DURATION_YEARS) {
+    return { ok: false, error: `Goal range must be ${MAX_DURATION_YEARS} years or less.` };
   }
 
   return {
@@ -78,13 +109,36 @@ export function normalizeStudentViewInput(input: {
     value: {
       studyStartDate,
       universityName,
-      studyDurationYears: duration,
+      goalEndDate: formatIsoDate(parsedGoalEndDate),
+      studyDurationYears: spanYears,
     },
   };
 }
 
 export function getAcademicGraduationDate(startDate: Date, durationYears: number): Date {
-  return new Date(startDate.getFullYear() + durationYears, 6, 31, 23, 59, 59, 999);
+  return new Date(Date.UTC(startDate.getUTCFullYear() + durationYears, 6, 31));
+}
+
+export function deriveGoalEndDateFromDuration(
+  studyStartDate: string,
+  studyDurationYears?: number | string
+): string {
+  const parsedStartDate = parseIsoDate(String(studyStartDate || '').trim());
+  const duration = typeof studyDurationYears === 'number'
+    ? studyDurationYears
+    : Number.parseInt(String(studyDurationYears || '').trim(), 10);
+
+  if (!parsedStartDate || !Number.isInteger(duration) || duration < 1 || duration > MAX_DURATION_YEARS) {
+    return '';
+  }
+
+  return formatIsoDate(getAcademicGraduationDate(parsedStartDate, duration));
+}
+
+export function getGoalSpanYears(startDate: Date, goalEndDate: Date): number {
+  const diffMs = goalEndDate.getTime() - startDate.getTime();
+  const spanYears = Math.ceil(diffMs / YEAR_MS);
+  return Math.max(spanYears, 1);
 }
 
 export function isSafeWallpaperDimension(value: number, min: number, max: number): boolean {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -28,8 +28,9 @@ export interface DeviceModel {
  * View mode for the wallpaper visualization
  * - 'year': Shows only the current year (52 weeks)
  * - 'life': Shows entire life span (4160 weeks for 80 years)
+ * - 'student': Shows study progress from enrollment to graduation
  */
-export type ViewMode = 'year' | 'life';
+export type ViewMode = 'year' | 'life' | 'student';
 
 /**
  * Days layout mode for year view
@@ -45,6 +46,15 @@ export type DaysLayoutMode = 'calendar' | 'continuous';
 export interface UserProfile {
   /** Birth date in YYYY-MM-DD format (ISO 8601 date string) */
   birthDate: string;
+
+  /** Study start date in YYYY-MM-DD format */
+  studyStartDate?: string;
+
+  /** University name for student view */
+  universityName?: string;
+
+  /** Study duration in years */
+  studyDurationYears?: number;
   
   /** Theme color in hex format (e.g., "#FF6B35") */
   themeColor: string;
@@ -81,6 +91,15 @@ export interface UserProfile {
 export interface WallpaperParams {
   /** Birth date in YYYY-MM-DD format */
   birthDate: string;
+
+  /** Study start date in YYYY-MM-DD format */
+  studyStartDate?: string;
+
+  /** University name for student view */
+  universityName?: string;
+
+  /** Study duration in years */
+  studyDurationYears?: number;
   
   /** Theme color in hex format (without # symbol for URL encoding) */
   themeColor: string;
@@ -159,6 +178,15 @@ export interface UserConfig {
   
   /** Birth date in YYYY-MM-DD format */
   birthDate: string;
+
+  /** Study start date in YYYY-MM-DD format */
+  studyStartDate?: string;
+
+  /** University name for student view */
+  universityName?: string;
+
+  /** Study duration in years */
+  studyDurationYears?: number;
   
   /** View mode: year or life */
   viewMode: ViewMode;
@@ -313,6 +341,15 @@ export interface PluginExecutionContext {
   
   /** Birth date */
   birthDate?: string;
+
+  /** Study start date */
+  studyStartDate?: string;
+
+  /** University name */
+  universityName?: string;
+
+  /** Study duration in years */
+  studyDurationYears?: number;
   
   /** View mode */
   viewMode?: ViewMode;
@@ -374,6 +411,15 @@ export interface PluginContext {
   
   /** User's birthdate */
   birthDate: string;
+
+  /** Study start date */
+  studyStartDate?: string;
+
+  /** University name */
+  universityName?: string;
+
+  /** Study duration in years */
+  studyDurationYears?: number;
   
   /** Device dimensions */
   width: number;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -53,6 +53,9 @@ export interface UserProfile {
   /** University name for student view */
   universityName?: string;
 
+  /** Goal end date in YYYY-MM-DD format */
+  goalEndDate?: string;
+
   /** Study duration in years */
   studyDurationYears?: number;
   
@@ -97,6 +100,9 @@ export interface WallpaperParams {
 
   /** University name for student view */
   universityName?: string;
+
+  /** Goal end date in YYYY-MM-DD format */
+  goalEndDate?: string;
 
   /** Study duration in years */
   studyDurationYears?: number;
@@ -184,6 +190,9 @@ export interface UserConfig {
 
   /** University name for student view */
   universityName?: string;
+
+  /** Goal end date in YYYY-MM-DD format */
+  goalEndDate?: string;
 
   /** Study duration in years */
   studyDurationYears?: number;
@@ -348,6 +357,9 @@ export interface PluginExecutionContext {
   /** University name */
   universityName?: string;
 
+  /** Goal end date */
+  goalEndDate?: string;
+
   /** Study duration in years */
   studyDurationYears?: number;
   
@@ -417,6 +429,9 @@ export interface PluginContext {
 
   /** University name */
   universityName?: string;
+
+  /** Goal end date */
+  goalEndDate?: string;
 
   /** Study duration in years */
   studyDurationYears?: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -529,6 +530,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.6.tgz",
       "integrity": "sha512-4uyt8BOrBsSq6i4yiOV/gG6BnnrvTeyymlNcaN/dKvyU1GoolxAafvIvaNP1RCGPlNab3OuE4MKUQuv2lH+PLQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -595,6 +597,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.6.tgz",
       "integrity": "sha512-YYGARbutghQY4zZUWMYia0ib0Y/rb52y72/N0z3vglRHL7ii/AaK9SA7S/dzScVOlCdnbHXz+sc5Dq+r8fwFAg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.6",
         "@firebase/component": "0.7.0",
@@ -610,7 +613,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.12.0",
@@ -1061,6 +1065,7 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2522,6 +2527,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2601,6 +2607,7 @@
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -3124,6 +3131,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3526,6 +3534,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4238,6 +4247,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4423,6 +4433,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7613,6 +7624,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7622,6 +7634,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8550,6 +8563,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8719,6 +8733,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9145,6 +9160,7 @@
       "integrity": "sha512-Zw/uYiiyF6pUT1qmKbZziChgNPRu+ZRneAsMUDU6IwmXdWt5JwcUfy2bvLOCUtz5UniaN/Zx5aFttZYbYc7O/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
- turn the former student view into a goal view flow
- switch goal setup from duration-based input to explicit start and end dates
- make the generated goal wallpaper match the simpler year-view visual style
- add a lightweight goal wallpaper preview link beneath the generated URL

## Details
- update the shared goal input model and server-side parsing to support `goalEndDate`
- refresh the public page and dashboard goal form to use simpler textfields
- simplify the goal renderer so it feels consistent with the existing wallpaper modes
- add a dedicated `GoalWallpaperPreview` component and place it in the result area
- remove the extra goal-specific install action so the output flow stays minimal

## Verification
- `npx eslint components/GoalWallpaperPreview.tsx`
- `GET /` returns `200 OK`
- `GET /api/wallpaper?...&viewMode=student&goalEndDate=2026-07-31` returns `200 OK` as `image/png`